### PR TITLE
Add geo types to supported types in docs

### DIFF
--- a/docs/usage/types/supported_types.md
+++ b/docs/usage/types/supported_types.md
@@ -35,6 +35,12 @@ Here you can find all types supported by `PSQLPy`. If PSQLPy isn't `-`, you can 
 | IPv6Address | - | INET |
 | decimal.Decimal | - | NUMERIC |
 | int/str | Money | MONEY |
+| Point | PyPoint | POINT |
+| Box | PyBox | BOX |
+| Path | PyPath | PATH |
+| Line | PyLine | LINE |
+| Line Segment | PyLineSegment | LSEG |
+| Circle | PyCircle | CIRCLE |
 
 ::: important
 DECIMAL PostgreSQL type isn't supported, use NUMERIC instead.


### PR DESCRIPTION
Add geo types to supported types in docs

## Description
Geo types were added but supported types docs wasn`t updated. So i updated it now.

## Motivation and Context
Nonactual docs.

## How has this been tested?
Not needed.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
