### PR TITLE
Replace `pre-commit` with `prek`

### DIFF
--- a/.github/workflows/prek.yaml
+++ b/.github/workflows/prek.yaml
@@ -1,0 +1,9 @@
+name: Prek checks
+on: [push, pull_request]
+
+jobs:
+  prek:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: j178/prek-action@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,11 +3,11 @@ ci:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.5.1
+    rev: v2.1.0
     hooks:
       - id: mypy
         name: python mypy
@@ -15,18 +15,13 @@ repos:
         pass_filenames: false
         args: ["python"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.1
+    rev: v0.15.13
     hooks:
-      - id: ruff
-        name: ruff
-        pass_filenames: false
-        always_run: true
-        args: ["python", "--fix"]
+      # Run the linter.
+      - id: ruff-check
+        args: [ --fix ]
+      # Run the formatter.
       - id: ruff-format
-        name: ruff
-        pass_filenames: false
-        always_run: true
-        args: ["python"]
   - repo: local
     hooks:
       - id: fmt

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -22,7 +22,7 @@ One of the best ways is follow [maturin offical documentation](https://www.matur
 ```bash
 > python3 -m venv .venv
 > source .venv/bin/activate
-> pip install -U pip maturin pre-commit pytest pytest-anyio pydantic pgpq
+> pip install -U pip maturin prek pytest pytest-anyio pydantic pgpq
 ```
 
 Then you need to build `PSQLPy` project.
@@ -33,12 +33,12 @@ maturin develop
 After this step project is built and installed in your python environment you created in previous step.
 
 ## Linting and type checking
-We have pre-commit configured with all our settings. We highly recommend you to install it as a git hook using pre-commit install command.
+We have prek configured with all our settings. We highly recommend you to install it as a git hook using prek install command.
 
 But even without installation, you can run all lints manually:
 
 ```bash
-pre-commit run -a
+prek run -a
 ```
 
 ## Testing

--- a/psqlpy-stress/.pre-commit-config.yaml
+++ b/psqlpy-stress/.pre-commit-config.yaml
@@ -1,8 +1,9 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
+orphan: true
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+    rev: v6.0.0
     hooks:
       - id: check-ast
       - id: trailing-whitespace
@@ -10,20 +11,24 @@ repos:
       - id: end-of-file-fixer
 
   - repo: https://github.com/asottile/add-trailing-comma
-    rev: v2.1.0
+    rev: v4.0.0
     hooks:
       - id: add-trailing-comma
 
-  - repo: local
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v2.1.0
     hooks:
-      - id: ruff
-        name: Check with ruff
-        entry: poetry run ruff check --force-exclude
-        language: system
-        types: [python]
-
       - id: mypy
-        name: Validate types with MyPy
-        entry: poetry run mypy
-        language: system
-        types: [python]
+        name: python mypy
+        always_run: true
+        pass_filenames: false
+        args: ["psqlpy_stress"]
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.13
+    hooks:
+      # Run the linter.
+      - id: ruff-check
+        args: [ --fix ]
+      # Run the formatter.
+      - id: ruff-format

--- a/psqlpy-stress/psqlpy_stress/migrations/env.py
+++ b/psqlpy-stress/psqlpy_stress/migrations/env.py
@@ -1,4 +1,16 @@
 # noqa: INP001
+"""Alembic migration environment.
+
+To enable autogenerate support, point ``target_metadata`` at your models::
+
+    from myapp import mymodel
+    target_metadata = mymodel.Base.metadata
+
+Additional values from alembic.ini can be read via ``config.get_main_option``::
+
+    my_important_option = config.get_main_option("my_important_option")
+"""
+
 from logging.config import fileConfig
 
 from alembic import context
@@ -17,19 +29,10 @@ config = context.config
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
 
-# add your model's MetaData object here
-# for 'autogenerate' support
-# from myapp import mymodel
-# target_metadata = mymodel.Base.metadata
 target_metadata = Base.metadata
 
 database_url = settings.database_url
 config.set_main_option("sqlalchemy.url", database_url)
-
-# other values from the config, defined by the needs of env.py,
-# can be acquired:
-# my_important_option = config.get_main_option("my_important_option")
-# ... etc.
 
 
 def run_migrations_offline() -> None:

--- a/psqlpy-stress/psqlpy_stress/migrations/versions/06d989926550_basic_user_table.py
+++ b/psqlpy-stress/psqlpy_stress/migrations/versions/06d989926550_basic_user_table.py
@@ -1,3 +1,4 @@
+# ruff: noqa: INP001
 """basic user table
 
 Revision ID: 06d989926550
@@ -7,7 +8,6 @@ Create Date: 2024-04-06 12:33:16.052321
 """
 
 from collections.abc import Sequence
-from typing import Union
 
 import sqlalchemy as sa
 from alembic import op
@@ -15,9 +15,9 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "06d989926550"
-down_revision: Union[str, None] = None
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/psqlpy-stress/psqlpy_stress/migrations/versions/d162c084f522_big_af_table.py
+++ b/psqlpy-stress/psqlpy_stress/migrations/versions/d162c084f522_big_af_table.py
@@ -1,3 +1,4 @@
+# ruff: noqa: INP001
 """big af table
 
 Revision ID: d162c084f522
@@ -7,7 +8,6 @@ Create Date: 2024-06-25 16:29:17.081234
 """
 
 from collections.abc import Sequence
-from typing import Union
 
 import sqlalchemy as sa
 from alembic import op
@@ -16,9 +16,9 @@ from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
 revision: str = "d162c084f522"
-down_revision: Union[str, None] = "06d989926550"
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = "06d989926550"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/psqlpy-stress/psqlpy_stress/mocker.py
+++ b/psqlpy-stress/psqlpy_stress/mocker.py
@@ -25,12 +25,12 @@ async def fill_users() -> None:
         )
 
 
-def generate_random_array() -> list[str]:
-    return [random.randint(50, 500) for _ in range(random.randint(50, 500))]
+def generate_random_array() -> list[int]:
+    return [random.randint(50, 500) for _ in range(random.randint(50, 500))]  # noqa: S311
 
 
 def generate_random_dict() -> dict[str, str]:
-    return {str(uuid.uuid4()): str(uuid.uuid4()) for _ in range(random.randint(50, 500))}
+    return {str(uuid.uuid4()): str(uuid.uuid4()) for _ in range(random.randint(50, 500))}  # noqa: S311
 
 
 async def fill_big_table() -> None:
@@ -39,10 +39,12 @@ async def fill_big_table() -> None:
     connection = await pool.connection()
     for _ in range(big_table_amount):
         await connection.execute(
-            "INSERT INTO big_table (string_field, integer_field, json_field, array_field) VALUES($1, $2, $3, $4)",
+            "INSERT INTO big_table"
+            " (string_field, integer_field, json_field, array_field)"
+            " VALUES($1, $2, $3, $4)",
             parameters=[
                 str(uuid.uuid4()),
-                random.randint(1, 99999999),
+                random.randint(1, 99999999),  # noqa: S311
                 generate_random_dict(),
                 generate_random_array(),
             ],

--- a/psqlpy-stress/psqlpy_stress/models/piccolo.py
+++ b/psqlpy-stress/psqlpy_stress/models/piccolo.py
@@ -2,12 +2,12 @@ from piccolo.columns import JSONB, Array, Integer, Serial, Varchar
 from piccolo.table import Table
 
 
-class User(Table, tablename="users"):
+class User(Table, tablename="users"):  # type: ignore[call-arg]
     user_id = Serial(primary_key=True)
     username = Varchar(null=False)
 
 
-class SomeBigTable(Table, tablename="big_table"):
+class SomeBigTable(Table, tablename="big_table"):  # type: ignore[call-arg]
     big_table_id = Integer(primary_key=True)
     string_field = Varchar(null=False)
     integer_field = Integer(null=False)

--- a/psqlpy-stress/psqlpy_stress/models/sqlalchemy.py
+++ b/psqlpy-stress/psqlpy_stress/models/sqlalchemy.py
@@ -6,14 +6,14 @@ from sqlalchemy.ext.declarative import declarative_base
 Base = declarative_base()
 
 
-class User(Base):
+class User(Base):  # type: ignore[misc, valid-type]
     __tablename__ = "users"
 
     user_id = Column(Integer, primary_key=True, autoincrement=True)
     username = Column(String, unique=True, nullable=False)
 
 
-class SomeBigTable(Base):
+class SomeBigTable(Base):  # type: ignore[misc, valid-type]
     __tablename__ = "big_table"
     big_table_id = Column(Integer, primary_key=True, autoincrement=True)
     string_field = Column(String, unique=False, nullable=False)

--- a/psqlpy-stress/psqlpy_stress/settings.py
+++ b/psqlpy-stress/psqlpy_stress/settings.py
@@ -4,9 +4,9 @@ from pydantic_settings import BaseSettings
 
 
 class DriversEnum(enum.StrEnum):
-    PSQLPY: str = "psqlpy"
-    ASYNCPG: str = "asyncpg"
-    PSYCOPG: str = "psycopg"
+    PSQLPY = "psqlpy"
+    ASYNCPG = "asyncpg"
+    PSYCOPG = "psycopg"
 
 
 class Settings(BaseSettings):

--- a/psqlpy-stress/pyproject.toml
+++ b/psqlpy-stress/pyproject.toml
@@ -35,8 +35,12 @@ requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.ruff]
+line-length = 89
+
+[tool.ruff.lint]
 ignore = [
     "ANN401",
+    "COM812",
     "SLF001",
     "TRY003",
     "PLR0913",
@@ -47,13 +51,18 @@ ignore = [
     "D",
     "T201",
 ]
-line-length = 89
 select = ["ALL"]
 fixable = ["ALL"]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 lines-after-imports = 2
 no-lines-before = ["standard-library", "local-folder"]
 
 [tool.mypy]
 strict = true
+ignore_missing_imports = true
+allow_subclassing_any = true
+allow_untyped_calls = true
+allow_untyped_decorators = true
+warn_return_any = false
+warn_unused_ignores = false

--- a/psqlpy-stress/pyproject.toml
+++ b/psqlpy-stress/pyproject.toml
@@ -26,7 +26,7 @@ piccolo = "^1.12.0"
 
 
 [tool.poetry.group.dev.dependencies]
-pre-commit = "*"
+prek = "*"
 mypy = "*"
 ruff = "*"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,18 @@ maintainers = [{ name = "Kiselev Aleksandr", email = "askiselev00@gmail.com" }]
 description = "Async PostgreSQL driver for Python written in Rust"
 dynamic = ["version"]
 
+[dependency-groups]
+dev = [
+  {include-group = "lint"},
+  {include-group = "test"}
+]
+lint = [
+  "ruff"
+]
+test = [
+  "pytest"
+]
+
 [tool.maturin]
 python-source = "python"
 module-name = "psqlpy._internal"
@@ -89,7 +101,7 @@ ignore = [
     "S311",
 ]
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "python/psqlpy/*" = ["PYI021"]
 "python/tests/*" = [
     "S101", # Use of assert detected
@@ -104,7 +116,7 @@ ignore = [
 "./psqlpy-stress/psqlpy_stress/migrations/env.py" = ["INP001"]
 "examples/*" = ["INP001"]
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "pep257"
 ignore-decorators = ["typing.overload"]
 

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -56,7 +56,7 @@ def postgres_password() -> str:
 
 @pytest.fixture
 def postgres_port() -> int:
-    return int(os.environ.get("POSTGRES_PORT", 5432))
+    return int(os.environ.get("POSTGRES_PORT", "5432"))
 
 
 @pytest.fixture

--- a/python/tests/test_binary_copy.py
+++ b/python/tests/test_binary_copy.py
@@ -37,7 +37,7 @@ CREATE TABLE IF NOT EXISTS cars (
     )
 
     arrow_table = parquet.read_table(
-        f"{os.path.dirname(os.path.abspath(__file__))}/test_data/MTcars.parquet",  # noqa: PTH120, PTH100
+        f"{os.path.dirname(os.path.abspath(__file__))}/test_data/MTcars.parquet",  # noqa: PTH120, PTH100, ASYNC240
     )
     encoder = ArrowToPostgresBinaryEncoder(arrow_table.schema)
     buf = BytesIO()
@@ -90,7 +90,7 @@ CREATE TABLE IF NOT EXISTS cars (
     )
 
     arrow_table = parquet.read_table(
-        f"{os.path.dirname(os.path.abspath(__file__))}/test_data/MTcars.parquet",  # noqa: PTH120, PTH100
+        f"{os.path.dirname(os.path.abspath(__file__))}/test_data/MTcars.parquet",  # noqa: PTH120, PTH100, ASYNC240
     )
     encoder = ArrowToPostgresBinaryEncoder(arrow_table.schema)
     buf = BytesIO()

--- a/python/tests/test_value_converter.py
+++ b/python/tests/test_value_converter.py
@@ -302,34 +302,6 @@ async def test_deserialization_simple_into_python(
     await connection.execute(f"DROP TABLE IF EXISTS {table_name}")
 
 
-async def test_aboba(
-    psql_pool: ConnectionPool,
-    postgres_type: str = "INT2",
-    py_value: Any = 2,
-    expected_deserialized: Any = 2,
-) -> None:
-    """Test how types can cast from Python and to Python."""
-    connection = await psql_pool.connection()
-    await connection.execute("DROP TABLE IF EXISTS for_test")
-    create_table_query = f"""
-    CREATE TABLE for_test (test_field {postgres_type})
-    """
-    insert_data_query = """
-    INSERT INTO for_test VALUES ($1)
-    """
-    await connection.execute(querystring=create_table_query)
-    await connection.execute(
-        querystring=insert_data_query,
-        parameters=[py_value],
-    )
-
-    raw_result = await connection.execute(
-        querystring="SELECT test_field FROM for_test",
-    )
-
-    assert raw_result.result()[0]["test_field"] == expected_deserialized
-
-
 async def test_deserialization_composite_into_python(
     psql_pool: ConnectionPool,
 ) -> None:


### PR DESCRIPTION
## Description
Replace `pre-commit` with `prek` across the repository, bring all hook configurations up to current revisions, migrate ruff/mypy config to current conventions, and fix the linter violations those updates surface.

**Changes in this PR:**
- Migrate dev tooling from `pre-commit` to `prek`; add CI workflow using `j178/prek-action`
- Bump hook revisions (pre-commit-hooks v5→v6, mirrors-mypy v1.5→v2.1, ruff-pre-commit v0.8→v0.15); switch to the canonical `ruff-check` + `ruff-format` hook split; fix the mypy hook to pass a target module when `pass_filenames: false`; add `orphan: true` to psqlpy-stress config so prek treats it as an independent config
- Migrate `[tool.ruff.per-file-ignores]` / `[tool.ruff.pydocstyle]` to the `[tool.ruff.lint.*]` namespace (deprecated at top level since ruff 0.2); add `[dependency-groups]` to root `pyproject.toml`; extend psqlpy-stress mypy config with flags required for its untyped third-party dependencies (sqlalchemy, piccolo, asyncpg)
- Fix violations surfaced by the updated config: `ERA001` Alembic boilerplate rephrased as a module docstring, `INP001` on migration version files, `S311`, `PLW1508`, `ASYNC240`, mypy 2.x StrEnum annotation requirement, and `declarative_base` / Piccolo `Table` subclass type ignores
- Remove `test_aboba`: a dead duplicate of `test_deserialization_simple_into_python` (same body, default args already covered by the parametrized cases, and a fixed `for_test` table name unsafe under parallel test execution)

## Motivation and Context
`prek` is the preferred successor to `pre-commit`. Combining the migration with a pass over current hook and config conventions keeps the toolchain consistent and clears accumulated linter debt in one PR.

## How has this been tested?
`prek run --all-files` passes cleanly across both the root and `psqlpy-stress` configs.

## Screenshots (if appropriate):
N/A

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
