### PR TITLE
Drop psqlpy-python forks; resolve all deps through crates.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,7 +87,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -131,11 +137,11 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -158,7 +164,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -197,9 +203,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
@@ -223,6 +229,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,7 +250,7 @@ dependencies = [
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -244,7 +261,7 @@ checksum = "d59ae0466b83e838b81a54256c39d5d7c20b9d7daa10510a242d9b75abd5936e"
 dependencies = [
  "chrono",
  "chrono-tz-build",
- "phf",
+ "phf 0.11.3",
 ]
 
 [[package]]
@@ -254,9 +271,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "433e39f13c9a060046954e0592a8d0a4bcb1040125cbf91cb8ee58964cfb350f"
 dependencies = [
  "parse-zoneinfo",
- "phf",
+ "phf 0.11.3",
  "phf_codegen",
 ]
+
+[[package]]
+name = "cmov"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f88a43d011fc4a6876cb7344703e297c71dda42494fee094d5f7c76bf13f746"
+
+[[package]]
+name = "const-oid"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
 name = "core-foundation-sys"
@@ -266,37 +295,48 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
- "generic-array",
- "typenum",
+ "hybrid-array",
+]
+
+[[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
 ]
 
 [[package]]
 name = "deadpool"
-version = "0.12.1"
-source = "git+https://github.com/psqlpy-python/deadpool.git?branch=psqlpy#c6121f18f69be055f90c94312d1d12cb62e34c11"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
 dependencies = [
  "deadpool-runtime",
+ "lazy_static",
  "num_cpus",
  "tokio",
 ]
 
 [[package]]
 name = "deadpool-postgres"
-version = "0.14.0"
-source = "git+https://github.com/psqlpy-python/deadpool.git?branch=psqlpy#c6121f18f69be055f90c94312d1d12cb62e34c11"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d697d376cbfa018c23eb4caab1fd1883dd9c906a8c034e8d9a3cb06a7e0bef9"
 dependencies = [
  "async-trait",
  "deadpool",
@@ -309,20 +349,22 @@ dependencies = [
 [[package]]
 name = "deadpool-runtime"
 version = "0.1.4"
-source = "git+https://github.com/psqlpy-python/deadpool.git?branch=psqlpy#c6121f18f69be055f90c94312d1d12cb62e34c11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
- "subtle",
+ "ctutils",
 ]
 
 [[package]]
@@ -342,6 +384,12 @@ name = "fallible-iterator"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foreign-types"
@@ -420,7 +468,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -451,16 +499,6 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -495,8 +533,22 @@ checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasi 0.14.2+wasi-0.2.4",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -519,6 +571,9 @@ name = "hashbrown"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -534,11 +589,20 @@ checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hmac"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -566,6 +630,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "indexmap"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -573,13 +643,17 @@ checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.4",
+ "serde",
 ]
 
 [[package]]
 name = "indoc"
-version = "2.0.6"
+version = "2.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "inventory"
@@ -607,25 +681,48 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.174"
+name = "lazy_static"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "lock_api"
@@ -651,9 +748,9 @@ checksum = "baee0bbc17ce759db233beb01648088061bf678383130602a298e6998eedb2d8"
 
 [[package]]
 name = "md-5"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
  "digest",
@@ -715,6 +812,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -752,7 +867,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -817,8 +932,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pg_interval"
-version = "0.4.2"
-source = "git+https://github.com/psqlpy-python/rust-postgres-interval.git?branch=psqlpy#7b407180ddc6653157163152efa29798163ffde2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceff720b1579b383347d48e5df5f604042adaa6a06f640b1f1e3c065f40766d"
 dependencies = [
  "bytes",
  "chrono",
@@ -827,8 +943,9 @@ dependencies = [
 
 [[package]]
 name = "pgvector"
-version = "0.4.0"
-source = "git+https://github.com/psqlpy-python/pgvector-rust.git?branch=psqlpy#311434c6963b8074dee693ce6e73651d1eafc349"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3673cba5b9a124916096a423b806a9f29620972c6c97b08db5f2053e9428b481"
 dependencies = [
  "bytes",
  "postgres-types",
@@ -840,7 +957,17 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
- "phf_shared",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_shared 0.13.1",
+ "serde",
 ]
 
 [[package]]
@@ -850,7 +977,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.11.3",
 ]
 
 [[package]]
@@ -859,8 +986,8 @@ version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
- "phf_shared",
- "rand",
+ "phf_shared 0.11.3",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -868,6 +995,15 @@ name = "phf_shared"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
 ]
@@ -898,19 +1034,21 @@ checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
 name = "postgres-derive"
-version = "0.4.5"
-source = "git+https://github.com/psqlpy-python/rust-postgres.git?branch=psqlpy#5780895bfa8a0b9142df225b65bc6e59f7dbee61"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca1dad89d9ffdbf78502fde418eeede499b87772d88be780478f7f76dc8d471f"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "postgres-openssl"
-version = "0.5.0"
-source = "git+https://github.com/psqlpy-python/rust-postgres.git?branch=psqlpy#5780895bfa8a0b9142df225b65bc6e59f7dbee61"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06743eefaa1a5c0ef2ccb6d9abf6528790a229eabd62ddcabf9b2a3aeff09fa4"
 dependencies = [
  "openssl",
  "tokio",
@@ -920,8 +1058,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-protocol"
-version = "0.6.7"
-source = "git+https://github.com/psqlpy-python/rust-postgres.git?branch=psqlpy#5780895bfa8a0b9142df225b65bc6e59f7dbee61"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56201207dac53e2f38e848e31b4b91616a6bb6e0c7205b77718994a7f49e70fc"
 dependencies = [
  "base64",
  "byteorder",
@@ -930,15 +1069,16 @@ dependencies = [
  "hmac",
  "md-5",
  "memchr",
- "rand",
+ "rand 0.10.1",
  "sha2",
  "stringprep",
 ]
 
 [[package]]
 name = "postgres-types"
-version = "0.2.7"
-source = "git+https://github.com/psqlpy-python/rust-postgres.git?branch=psqlpy#5780895bfa8a0b9142df225b65bc6e59f7dbee61"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dc729a129e682e8d24170cd30ae1aa01b336b096cbb56df6d534ffec133d186"
 dependencies = [
  "array-init",
  "bytes",
@@ -947,7 +1087,7 @@ dependencies = [
  "geo-types",
  "postgres-derive",
  "postgres-protocol",
- "serde",
+ "serde_core",
  "serde_json",
  "uuid",
 ]
@@ -955,7 +1095,8 @@ dependencies = [
 [[package]]
 name = "postgres_array"
 version = "0.11.1"
-source = "git+https://github.com/psqlpy-python/rust-postgres-array.git?branch=psqlpy#510ffe38b8c34c7fed6b59f0b4e38f85f0040900"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2667c8b8c3a857620d87fc5172972c3385254a7563a5ab303bc9a41a16a7bf4e"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -970,6 +1111,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -998,6 +1149,7 @@ dependencies = [
  "bytes",
  "chrono",
  "chrono-tz",
+ "deadpool",
  "deadpool-postgres",
  "futures",
  "futures-channel",
@@ -1018,7 +1170,7 @@ dependencies = [
  "pyo3",
  "pyo3-async-runtimes",
  "regex",
- "rust_decimal 1.36.0",
+ "rust_decimal",
  "serde",
  "serde_json",
  "thiserror",
@@ -1049,9 +1201,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8970a78afe0628a3e3430376fc5fd76b6b45c4d43360ffd6cdd40bdde72b682a"
+checksum = "7ba0117f4212101ee6544044dae45abe1083d30ce7b29c4b5cbdfa2354e07383"
 dependencies = [
  "chrono",
  "indoc",
@@ -1063,14 +1215,15 @@ dependencies = [
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "rust_decimal 1.37.2",
+ "rust_decimal",
  "unindent",
 ]
 
 [[package]]
 name = "pyo3-async-runtimes"
-version = "0.25.0"
-source = "git+https://github.com/psqlpy-python/pyo3-async-runtimes.git?branch=psqlpy#74cd232b0606cd9e0dcab291bd10a8cadf69a1ed"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6ee6d4cb3e8d5b925f5cdb38da183e0ff18122eb2048d4041c9e7034d026e23"
 dependencies = [
  "futures",
  "once_cell",
@@ -1081,20 +1234,19 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458eb0c55e7ece017adeba38f2248ff3ac615e53660d7c71a238d7d2a01c7598"
+checksum = "4fc6ddaf24947d12a9aa31ac65431fb1b851b8f4365426e182901eabfb87df5f"
 dependencies = [
- "once_cell",
  "python3-dll-a",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7114fe5457c61b276ab77c5055f206295b812608083644a5c5b2640c3102565c"
+checksum = "025474d3928738efb38ac36d4744a74a400c901c7596199e20e45d98eb194105"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1102,27 +1254,27 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8725c0a622b374d6cb051d11a0983786448f7785336139c3c94f5aa6bef7e50"
+checksum = "2e64eb489f22fe1c95911b77c44cc41e7c19f3082fc81cce90f657cdc42ffded"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4109984c22491085343c05b0dbc54ddc405c3cf7b4374fc533f5c3313a572ccc"
+checksum = "100246c0ecf400b475341b8455a9213344569af29a3c841d29270e53102e0fcf"
 dependencies = [
  "heck",
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1150,6 +1302,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1163,7 +1321,18 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1173,7 +1342,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1184,6 +1353,12 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.16",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "redox_syscall"
@@ -1234,9 +1409,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.7.45"
+version = "0.7.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9008cd6385b9e161d8229e1f6549dd23c3d022f132a2ea37ac3a10ac4935779b"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
 dependencies = [
  "bitvec",
  "bytecheck",
@@ -1252,9 +1427,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.7.45"
+version = "0.7.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503d1d27590a2b0a3a4ca4c94755aa2875657196ecbf401a42eff41d7de532c0"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1263,28 +1438,20 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.36.0"
-source = "git+https://github.com/psqlpy-python/rust-decimal.git?branch=psqlpy#df8c0eee39c08ea3b5d7f0f24249137c67baaae5"
+version = "1.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c5108e3d4d903e21aac27f12ba5377b6b34f9f44b325e4894c7924169d06995"
 dependencies = [
  "arrayvec",
  "borsh",
  "bytes",
  "num-traits",
  "postgres-types",
- "rand",
+ "rand 0.8.5",
  "rkyv",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "rust_decimal"
-version = "1.37.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b203a6425500a03e0919c42d3c47caca51e79f1132046626d2c8871c5092035d"
-dependencies = [
- "arrayvec",
- "num-traits",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1300,12 +1467,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
-name = "ryu"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1318,42 +1479,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
-name = "serde"
-version = "1.0.219"
+name = "semver"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
- "ryu",
  "serde",
+ "serde_core",
+ "zmij",
 ]
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1410,6 +1588,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1419,12 +1607,6 @@ dependencies = [
  "unicode-normalization",
  "unicode-properties",
 ]
-
-[[package]]
-name = "subtle"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -1439,9 +1621,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1456,9 +1638,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "target-lexicon"
-version = "0.13.2"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "thiserror"
@@ -1477,7 +1659,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1508,7 +1690,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.5.10",
  "tokio-macros",
  "windows-sys 0.52.0",
 ]
@@ -1521,7 +1703,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1537,8 +1719,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.11"
-source = "git+https://github.com/psqlpy-python/rust-postgres.git?branch=psqlpy#5780895bfa8a0b9142df225b65bc6e59f7dbee61"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd8df5ef180f6364759a6f00f7aadda4fbbac86cdee37480826a6ff9f3574ce"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -1549,12 +1732,12 @@ dependencies = [
  "log",
  "parking_lot",
  "percent-encoding",
- "phf",
+ "phf 0.13.1",
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
- "rand",
- "socket2",
+ "rand 0.10.1",
+ "socket2 0.6.3",
  "tokio",
  "tokio-util",
  "whoami",
@@ -1609,7 +1792,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1623,9 +1806,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.18.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-bidi"
@@ -1653,6 +1836,12 @@ name = "unicode-properties"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unindent"
@@ -1699,42 +1888,51 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasite"
-version = "0.1.0"
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasite"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.2+wasi-0.2.4",
+]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
+ "serde",
  "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn 2.0.104",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1742,31 +1940,65 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
- "wasm-bindgen-backend",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.77"
+name = "wasm-encoder"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.4",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1774,11 +2006,13 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.6.0"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6994d13118ab492c3c80c1f81928718159254c53c472bf9ce36f8dae4add02a7"
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
 dependencies = [
- "redox_syscall",
+ "libc",
+ "libredox",
+ "objc2-system-configuration",
  "wasite",
  "web-sys",
 ]
@@ -1791,7 +2025,7 @@ checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-result",
  "windows-strings",
 ]
@@ -1804,7 +2038,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1815,7 +2049,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1825,12 +2059,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -1839,7 +2079,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -1858,6 +2098,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1934,12 +2183,106 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
 name = "wit-bindgen-rt"
 version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn 2.0.117",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
 ]
 
 [[package]]
@@ -1968,5 +2311,11 @@ checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.117",
 ]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,14 @@ name = "psqlpy"
 crate-type = ["cdylib"]
 
 [dependencies]
-deadpool-postgres = { git = "https://github.com/psqlpy-python/deadpool.git", branch = "psqlpy" }
-pyo3 = { version = "0.25.1", features = [
+deadpool = { version = "0.12", features = ["managed"] }
+deadpool-postgres = "0.14"
+# TODO(python-3.10-drop): Bump pyo3/pyo3-async-runtimes to 0.28+. pyo3 0.27
+# dropped Python 3.10 support, which psqlpy still ships; once 3.10 EOL is
+# observed in this repo, also flip the source-side TODOs marked with the same
+# tag back to their 0.28 form (Python::attach, FromPyObject<'a, 'py>::extract,
+# OnceLockExt, pyclass(from_py_object), etc.).
+pyo3 = { version = "0.26", features = [
     "chrono",
     "experimental-async",
     "rust_decimal",
@@ -19,9 +25,7 @@ pyo3 = { version = "0.25.1", features = [
     "multiple-pymethods",
     "generate-import-lib",
 ] }
-pyo3-async-runtimes = { git = "https://github.com/psqlpy-python/pyo3-async-runtimes.git", branch = "psqlpy", features = [
-    "tokio-runtime",
-] }
+pyo3-async-runtimes = { version = "0.26", features = ["tokio-runtime"] }
 
 tokio = { version = "1.35.1", features = ["full"] }
 thiserror = "1.0.56"
@@ -35,31 +39,27 @@ serde_json = "1.0.113"
 futures-util = "0.3.30"
 macaddr = "1.0.1"
 geo-types = "0.7.13"
-postgres-types = { git = "https://github.com/psqlpy-python/rust-postgres.git", branch = "psqlpy", features = [
-    "derive",
-] }
-tokio-postgres = { git = "https://github.com/psqlpy-python/rust-postgres.git", branch = "psqlpy", features = [
+postgres-types = { version = "0.2", features = ["derive"] }
+tokio-postgres = { version = "0.7", features = [
     "with-serde_json-1",
     "array-impls",
     "with-chrono-0_4",
     "with-uuid-1",
     "with-geo-types-0_7",
 ] }
-postgres-protocol = { git = "https://github.com/psqlpy-python/rust-postgres.git", branch = "psqlpy" }
-postgres-openssl = { git = "https://github.com/psqlpy-python/rust-postgres.git", branch = "psqlpy" }
-rust_decimal = { git = "https://github.com/psqlpy-python/rust-decimal.git", branch = "psqlpy", features = [
+postgres-protocol = "0.6"
+postgres-openssl = "0.5"
+rust_decimal = { version = "1.42", features = [
     "db-postgres",
     "db-tokio-postgres",
 ] }
-postgres_array = { git = "https://github.com/psqlpy-python/rust-postgres-array.git", branch = "psqlpy" }
+postgres_array = "0.11"
 openssl = { version = "= 0.10.64", features = ["vendored"] }
 itertools = "0.12.1"
 openssl-src = "= 300.2.2"
 openssl-sys = "= 0.9.102"
-pg_interval = { git = "https://github.com/psqlpy-python/rust-postgres-interval.git", branch = "psqlpy" }
-pgvector = { git = "https://github.com/psqlpy-python/pgvector-rust.git", branch = "psqlpy", features = [
-    "postgres",
-] }
+pg_interval = "0.4"
+pgvector = { version = "0.4", features = ["postgres"] }
 futures-channel = "0.3.31"
 futures = "0.3.31"
 regex = "1.11.1"

--- a/python/tests/test_ssl_mode_allow_retry.py
+++ b/python/tests/test_ssl_mode_allow_retry.py
@@ -10,26 +10,34 @@ plain `host` entries) for the TCP rows. With that config:
   - A TLS connection succeeds.
 
 Three assertions:
-  (a) `ssl_mode=Allow` + a CA file succeeds — the plaintext attempt is
-      rejected, `PsqlpyManager` walks the `source()` chain, detects the
-      "no encryption" diagnostic, and re-runs `create()` through the TLS
-      fallback inner manager.
-  (b) `ssl_mode=Disable` fails — there is no fallback, the rejection
-      bubbles up unchanged. We assert the failure surfaces some signal of
-      the postgres-side denial.
+  (a) `ssl_mode=Allow` + a CA file succeeds AND postgres logs show a
+      preceding plaintext rejection from the same test window — proves the
+      retry actually fired, distinguishing it from a degenerate "Allow ==
+      Require" implementation that would skip plaintext entirely.
+  (b) `ssl_mode=Disable` fails with a `BaseConnectionPoolError` — there is
+      no fallback, so the rejection bubbles up as a connection-pool
+      backend failure. (psqlpy wraps tokio-postgres errors so the
+      SQLSTATE/"no encryption" text doesn't survive to Python; the
+      docker-log probe below carries the SQLSTATE signal when available.)
   (c) `ssl_mode=Require` + a CA file succeeds — control case, never goes
       through the plaintext side.
 
 These tests are skipped automatically unless `PSQLPY_HOSTSSL_PORT` is set,
 because the hostssl-only postgres is bespoke infra, not the regular
-`POSTGRES_PORT` server used by the rest of the suite.
+`POSTGRES_PORT` server used by the rest of the suite. If
+`PSQLPY_HOSTSSL_DOCKER_CONTAINER` is also set, the Allow / Disable cases
+additionally assert against `docker logs` from that container — that's
+how we observe the retry actually firing rather than inferring it from a
+green query alone.
 """
 
 import os
+import subprocess
+import time
 
 import pytest
 from psqlpy import ConnectionPool, SslMode
-from psqlpy.exceptions import ConnectionPoolBuildError, ConnectionPoolExecuteError
+from psqlpy.exceptions import BaseConnectionPoolError
 
 pytestmark = [
     pytest.mark.anyio,
@@ -75,6 +83,37 @@ def hostssl_cert_file() -> str:
     return path
 
 
+def _docker_logs_since(container: str, since_epoch: float) -> str | None:
+    """Return docker logs from `container` newer than `since_epoch`.
+
+    Returns None when docker isn't available, the container doesn't exist,
+    or the lookup fails for any other reason — callers treat the absence
+    of logs as "skip the assertion" rather than as a test failure, because
+    the assertion is opt-in (only meaningful with the matching docker
+    infra). When the lookup succeeds, the return value is the combined
+    stdout+stderr of `docker logs --since=<ts>` decoded as utf-8.
+    """
+    try:
+        since_iso = time.strftime(
+            "%Y-%m-%dT%H:%M:%S",
+            time.gmtime(since_epoch),
+        )
+        proc = subprocess.run(  # noqa: S603 — container name is from env
+            ["docker", "logs", "--since", since_iso, container],  # noqa: S607
+            capture_output=True,
+            check=False,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    if proc.returncode != 0:
+        return None
+    return proc.stdout.decode("utf-8", errors="replace") + proc.stderr.decode(
+        "utf-8",
+        errors="replace",
+    )
+
+
 async def test_allow_retries_over_tls_when_hostssl_only(
     hostssl_host: str,
     hostssl_port: int,
@@ -83,7 +122,20 @@ async def test_allow_retries_over_tls_when_hostssl_only(
     hostssl_dbname: str,
     hostssl_cert_file: str,
 ) -> None:
-    """`SslMode.Allow` succeeds: PsqlpyManager falls back to TLS."""
+    """`SslMode.Allow` succeeds AND the retry path actually fires.
+
+    Without observing the retry directly, this test would also pass for a
+    degenerate implementation that mapped `Allow → Require` and skipped
+    the plaintext attempt entirely. To distinguish those two
+    implementations, we open the connection inside a window we can read
+    back from the postgres server log: if a plaintext attempt was made,
+    the server emitted a FATAL with SQLSTATE `28000` + the literal
+    "no encryption" string within that window. The log probe is opt-in
+    (`PSQLPY_HOSTSSL_DOCKER_CONTAINER`); when not provided we still
+    assert the green query result, but flag the weakness in skip text.
+    """
+    container = os.environ.get("PSQLPY_HOSTSSL_DOCKER_CONTAINER")
+    window_start = time.time()
     pool = ConnectionPool(
         username=hostssl_user,
         password=hostssl_password,
@@ -100,6 +152,28 @@ async def test_allow_retries_over_tls_when_hostssl_only(
     finally:
         pool.close()
 
+    if container is None:
+        pytest.skip(
+            "set PSQLPY_HOSTSSL_DOCKER_CONTAINER to also assert the retry "
+            "actually fired (the green query alone doesn't distinguish "
+            "true Allow retry from a degenerate Allow==Require mapping)",
+        )
+        msg = "unreachable: pytest.skip raises"
+        raise RuntimeError(msg)
+
+    logs = _docker_logs_since(container, window_start)
+    assert logs is not None, (
+        f"docker logs for container {container!r} were unreadable; cannot "
+        "verify that the plaintext attempt actually happened."
+    )
+    assert "no encryption" in logs, (
+        "Expected postgres server log to contain a 'no encryption' "
+        "rejection in the test window — that's the signal the Allow path "
+        "made the plaintext attempt first. Its absence means the "
+        "implementation may have skipped plaintext and gone straight to "
+        f"TLS (i.e. behaved as Require). Full log snippet:\n{logs[-2000:]}"
+    )
+
 
 async def test_disable_surfaces_no_encryption_rejection(
     hostssl_host: str,
@@ -115,6 +189,8 @@ async def test_disable_surfaces_no_encryption_rejection(
     don't pin the exception text — different driver versions wrap the
     diagnostic differently — but the connect or first query must fail.
     """
+    container = os.environ.get("PSQLPY_HOSTSSL_DOCKER_CONTAINER")
+    window_start = time.time()
     pool = ConnectionPool(
         username=hostssl_user,
         password=hostssl_password,
@@ -124,12 +200,29 @@ async def test_disable_surfaces_no_encryption_rejection(
         ssl_mode=SslMode.Disable,
     )
     try:
-        with pytest.raises(
-            (ConnectionPoolBuildError, ConnectionPoolExecuteError, Exception),
-        ):
+        with pytest.raises(BaseConnectionPoolError):
             await _connect_and_select_one(pool)
     finally:
         pool.close()
+
+    # psqlpy wraps tokio-postgres errors as a flat string with no SQLSTATE
+    # attribute exposed to Python; "db error" is all that survives the
+    # PoolError → Error → Display chain. So we cannot pin the SQLSTATE
+    # in-band — the SQLSTATE check rides on the postgres server log when
+    # docker access is available. Without it we still get the
+    # `BaseConnectionPoolError`-narrowed assertion above, which proves the
+    # connection failed (not a different unrelated exception).
+    if container is None:
+        return
+    logs = _docker_logs_since(container, window_start)
+    if logs is None:
+        return
+    assert "no encryption" in logs, (
+        "Expected the postgres server log to contain a 'no encryption' "
+        "rejection during the Disable-against-hostssl-only attempt. Its "
+        "absence means the failure mode wasn't the SSL-required diagnostic "
+        f"this test is meant to cover. Recent log:\n{logs[-2000:]}"
+    )
 
 
 async def _connect_and_select_one(pool: ConnectionPool) -> None:
@@ -137,8 +230,9 @@ async def _connect_and_select_one(pool: ConnectionPool) -> None:
 
     Either `pool.connection()` or the subsequent `execute` may raise
     depending on whether the rejection lands during the TCP handshake or
-    during the first round-trip; the test cares only that *something*
-    inside this call fails.
+    during the first round-trip; the test cares only that the
+    `BaseConnectionPoolError`-narrowed failure surfaces somewhere along
+    this two-step call.
     """
     conn = await pool.connection()
     await conn.execute("SELECT 1")

--- a/python/tests/test_ssl_mode_allow_retry.py
+++ b/python/tests/test_ssl_mode_allow_retry.py
@@ -1,0 +1,170 @@
+"""End-to-end check that `SslMode.Allow` actually retries over TLS.
+
+Pre-requisite: a `pg_hba.conf` that contains only `hostssl` entries (no
+plain `host` entries) for the TCP rows. With that config:
+
+  - A plaintext connection attempt is rejected by the server with SQLSTATE
+    `28000` (`INVALID_AUTHORIZATION_SPECIFICATION`) and the message
+    "no encryption". This is what `PsqlpyManager::is_ssl_required_rejection`
+    keys off.
+  - A TLS connection succeeds.
+
+Three assertions:
+  (a) `ssl_mode=Allow` + a CA file succeeds — the plaintext attempt is
+      rejected, `PsqlpyManager` walks the `source()` chain, detects the
+      "no encryption" diagnostic, and re-runs `create()` through the TLS
+      fallback inner manager.
+  (b) `ssl_mode=Disable` fails — there is no fallback, the rejection
+      bubbles up unchanged. We assert the failure surfaces some signal of
+      the postgres-side denial.
+  (c) `ssl_mode=Require` + a CA file succeeds — control case, never goes
+      through the plaintext side.
+
+These tests are skipped automatically unless `PSQLPY_HOSTSSL_PORT` is set,
+because the hostssl-only postgres is bespoke infra, not the regular
+`POSTGRES_PORT` server used by the rest of the suite.
+"""
+
+import os
+
+import pytest
+from psqlpy import ConnectionPool, SslMode
+from psqlpy.exceptions import ConnectionPoolBuildError, ConnectionPoolExecuteError
+
+pytestmark = [
+    pytest.mark.anyio,
+    pytest.mark.skipif(
+        os.environ.get("PSQLPY_HOSTSSL_PORT") is None,
+        reason="needs a hostssl-only postgres on PSQLPY_HOSTSSL_PORT",
+    ),
+]
+
+
+@pytest.fixture
+def hostssl_port() -> int:
+    return int(os.environ["PSQLPY_HOSTSSL_PORT"])
+
+
+@pytest.fixture
+def hostssl_host() -> str:
+    return os.environ.get("PSQLPY_HOSTSSL_HOST", "localhost")
+
+
+@pytest.fixture
+def hostssl_user() -> str:
+    return os.environ.get("PSQLPY_HOSTSSL_USER", "postgres")
+
+
+@pytest.fixture
+def hostssl_password() -> str:
+    return os.environ.get("PSQLPY_HOSTSSL_PASSWORD", "postgres")
+
+
+@pytest.fixture
+def hostssl_dbname() -> str:
+    return os.environ.get("PSQLPY_HOSTSSL_DBNAME", "psqlpy_test")
+
+
+@pytest.fixture
+def hostssl_cert_file() -> str:
+    path = os.environ.get("PSQLPY_HOSTSSL_CERT_FILE")
+    if path is None:
+        pytest.skip("PSQLPY_HOSTSSL_CERT_FILE not set")
+        msg = "unreachable: pytest.skip raises"
+        raise RuntimeError(msg)
+    return path
+
+
+async def test_allow_retries_over_tls_when_hostssl_only(
+    hostssl_host: str,
+    hostssl_port: int,
+    hostssl_user: str,
+    hostssl_password: str,
+    hostssl_dbname: str,
+    hostssl_cert_file: str,
+) -> None:
+    """`SslMode.Allow` succeeds: PsqlpyManager falls back to TLS."""
+    pool = ConnectionPool(
+        username=hostssl_user,
+        password=hostssl_password,
+        host=hostssl_host,
+        port=hostssl_port,
+        db_name=hostssl_dbname,
+        ssl_mode=SslMode.Allow,
+        ca_file=hostssl_cert_file,
+    )
+    try:
+        conn = await pool.connection()
+        result = await conn.execute("SELECT 1 AS one")
+        assert result.result()[0]["one"] == 1
+    finally:
+        pool.close()
+
+
+async def test_disable_surfaces_no_encryption_rejection(
+    hostssl_host: str,
+    hostssl_port: int,
+    hostssl_user: str,
+    hostssl_password: str,
+    hostssl_dbname: str,
+) -> None:
+    """`SslMode.Disable` against hostssl-only fails with the server's denial.
+
+    The retry path is intentionally unavailable here (Disable has no TLS
+    fallback inner manager), so the postgres-side rejection bubbles up. We
+    don't pin the exception text — different driver versions wrap the
+    diagnostic differently — but the connect or first query must fail.
+    """
+    pool = ConnectionPool(
+        username=hostssl_user,
+        password=hostssl_password,
+        host=hostssl_host,
+        port=hostssl_port,
+        db_name=hostssl_dbname,
+        ssl_mode=SslMode.Disable,
+    )
+    try:
+        with pytest.raises(
+            (ConnectionPoolBuildError, ConnectionPoolExecuteError, Exception),
+        ):
+            await _connect_and_select_one(pool)
+    finally:
+        pool.close()
+
+
+async def _connect_and_select_one(pool: ConnectionPool) -> None:
+    """Tiny helper so the `pytest.raises` body stays a single statement.
+
+    Either `pool.connection()` or the subsequent `execute` may raise
+    depending on whether the rejection lands during the TCP handshake or
+    during the first round-trip; the test cares only that *something*
+    inside this call fails.
+    """
+    conn = await pool.connection()
+    await conn.execute("SELECT 1")
+
+
+async def test_require_succeeds_with_ca_file(
+    hostssl_host: str,
+    hostssl_port: int,
+    hostssl_user: str,
+    hostssl_password: str,
+    hostssl_dbname: str,
+    hostssl_cert_file: str,
+) -> None:
+    """Control: `SslMode.Require` + ca_file goes straight through TLS."""
+    pool = ConnectionPool(
+        username=hostssl_user,
+        password=hostssl_password,
+        host=hostssl_host,
+        port=hostssl_port,
+        db_name=hostssl_dbname,
+        ssl_mode=SslMode.Require,
+        ca_file=hostssl_cert_file,
+    )
+    try:
+        conn = await pool.connection()
+        result = await conn.execute("SELECT 1 AS one")
+        assert result.result()[0]["one"] == 1
+    finally:
+        pool.close()

--- a/python/tests/test_statement_lifecycle.py
+++ b/python/tests/test_statement_lifecycle.py
@@ -18,38 +18,13 @@ from psqlpy import ConnectionPool
 
 pytestmark = pytest.mark.anyio
 
-
-async def _backend_pid(conn: object) -> int:
-    """Return the postgres backend PID for the given psqlpy Connection."""
-    result = await conn.execute("SELECT pg_backend_pid()", prepared=False)  # type: ignore[attr-defined]
-    return int(result.result()[0]["pg_backend_pid"])
-
-
-async def _prepared_count_for_pid(
-    pool: ConnectionPool,
-    pid: int,
-) -> int:
-    """Count entries in `pg_prepared_statements` for the given backend PID.
-
-    Uses a separate connection to avoid the question being asked through the
-    same prepared-statement cache it's measuring. `pg_prepared_statements` is
-    a per-session view, so we look at the target session from the outside via
-    `dblink`-free SQL: a regular query that filters on the saved PID by
-    asking postgres to introspect its own state for that PID.
-    """
-    other = await pool.connection()
-    # `pg_prepared_statements` is per-session; from another session we have to
-    # walk via the postgres stat views. There is no cross-session way to
-    # enumerate another session's prepared statements with plain SQL — but we
-    # can run the count in-band on the original connection by passing it a
-    # query that doesn't itself enter the prepared-statement cache. We do
-    # that in the caller; this helper is unused for the cross-session
-    # variant, kept here for documentation only.
-    _ = pid
-    _ = other
-    raise NotImplementedError(
-        "pg_prepared_statements is per-session; query it on the same conn.",
-    )
+# The in-band approach `pg_prepared_statements` is per-session, so both
+# tests issue the introspection query on the same `connection` object they
+# populated — opening a second pool connection would land on a different
+# backend with an empty per-session view. The introspection query itself
+# runs with `prepared=False` so it doesn't perturb the cache it's
+# measuring (no-parameter `prepared=False` uses tokio-postgres' unnamed
+# prepared statement which is dropped immediately).
 
 
 async def test_non_cached_prepare_does_not_leak_server_side(

--- a/python/tests/test_statement_lifecycle.py
+++ b/python/tests/test_statement_lifecycle.py
@@ -1,0 +1,163 @@
+"""Server-side prepared-statement lifecycle regression.
+
+Backs up the source-side change in `src/connection/impls.rs` that dropped the
+explicit `DEALLOCATE PREPARE` after non-cached prepares and started relying on
+tokio-postgres' `Drop for StatementInner` to send `Close('S', name) + Sync`
+when the last `Arc<StatementInner>` clone is dropped.
+
+If that wiring ever regresses (e.g. an outstanding clone keeps a Statement
+alive past the consumer's `Result`), `pg_prepared_statements` will start
+holding entries we never explicitly cleared, and the server-side resource
+slowly grows. This test catches that by making sure a burst of non-cached
+prepares lands at the same backend connection at zero prepared statements
+after the calls return.
+"""
+
+import pytest
+from psqlpy import ConnectionPool
+
+pytestmark = pytest.mark.anyio
+
+
+async def _backend_pid(conn: object) -> int:
+    """Return the postgres backend PID for the given psqlpy Connection."""
+    result = await conn.execute("SELECT pg_backend_pid()", prepared=False)  # type: ignore[attr-defined]
+    return int(result.result()[0]["pg_backend_pid"])
+
+
+async def _prepared_count_for_pid(
+    pool: ConnectionPool,
+    pid: int,
+) -> int:
+    """Count entries in `pg_prepared_statements` for the given backend PID.
+
+    Uses a separate connection to avoid the question being asked through the
+    same prepared-statement cache it's measuring. `pg_prepared_statements` is
+    a per-session view, so we look at the target session from the outside via
+    `dblink`-free SQL: a regular query that filters on the saved PID by
+    asking postgres to introspect its own state for that PID.
+    """
+    other = await pool.connection()
+    # `pg_prepared_statements` is per-session; from another session we have to
+    # walk via the postgres stat views. There is no cross-session way to
+    # enumerate another session's prepared statements with plain SQL — but we
+    # can run the count in-band on the original connection by passing it a
+    # query that doesn't itself enter the prepared-statement cache. We do
+    # that in the caller; this helper is unused for the cross-session
+    # variant, kept here for documentation only.
+    _ = pid
+    _ = other
+    raise NotImplementedError(
+        "pg_prepared_statements is per-session; query it on the same conn.",
+    )
+
+
+async def test_non_cached_prepare_does_not_leak_server_side(
+    postgres_host: str,
+    postgres_user: str,
+    postgres_password: str,
+    postgres_port: int,
+    postgres_dbname: str,
+) -> None:
+    """Non-cached prepares drop their Statement and send Close('S').
+
+    Sequence:
+      1. Open one pooled connection.
+      2. Run `SELECT 1` with `prepared=False` 50 times in a row on the same
+         connection.
+      3. From the same connection, count rows in `pg_prepared_statements`.
+         If the DEALLOCATE-removal kept its end of the bargain (Statement
+         Drop → Close), the count is zero. If statements leak, the count
+         grows roughly with the number of calls.
+    """
+    pool = ConnectionPool(
+        username=postgres_user,
+        password=postgres_password,
+        host=postgres_host,
+        port=postgres_port,
+        db_name=postgres_dbname,
+        max_db_pool_size=2,
+    )
+    try:
+        connection = await pool.connection()
+
+        for _ in range(50):
+            await connection.execute("SELECT 1", prepared=False)
+
+        # Same connection — `pg_prepared_statements` is per-session, so the
+        # query has to ride the same backend. Use `prepared=False` here too
+        # to avoid the introspection query itself populating the cache we're
+        # measuring.
+        leaked = await connection.execute(
+            "SELECT count(*)::bigint AS n FROM pg_prepared_statements",
+            prepared=False,
+        )
+        rows = leaked.result()
+        assert len(rows) == 1, rows
+        assert rows[0]["n"] == 0, (
+            f"Expected 0 prepared statements after non-cached prepares, found "
+            f"{rows[0]['n']}. This means tokio-postgres' Drop for "
+            f"StatementInner did not send Close('S') — the DEALLOCATE-removal "
+            f"in src/connection/impls.rs regressed."
+        )
+    finally:
+        pool.close()
+
+
+async def test_cached_prepare_retains_statements_while_held(
+    postgres_host: str,
+    postgres_user: str,
+    postgres_password: str,
+    postgres_port: int,
+    postgres_dbname: str,
+) -> None:
+    """`prepared=True` with parameters keeps the named statement alive.
+
+    Dual of the previous test for the path that *does* go through deadpool's
+    `prepare_cached`: queries that carry parameters route through the
+    StatementBuilder, which prepares a named statement and the
+    `deadpool_postgres::StatementCache` holds an `Arc<Statement>` clone. The
+    Statement is therefore not dropped after each call, and the cached
+    server-side prepared statement persists for the lifetime of the pooled
+    connection. Re-executing the same query string should reuse the same
+    cache entry, so `pg_prepared_statements` for that statement text shows
+    exactly one row no matter how many times we execute.
+
+    The no-parameter path (covered by `execute_no_params`) uses tokio's
+    unnamed-prepared-statement shortcut and never populates the cache, so
+    we deliberately use parameters here.
+    """
+    pool = ConnectionPool(
+        username=postgres_user,
+        password=postgres_password,
+        host=postgres_host,
+        port=postgres_port,
+        db_name=postgres_dbname,
+        max_db_pool_size=2,
+    )
+    try:
+        connection = await pool.connection()
+
+        # Parameterised → goes through StatementBuilder → prepare_cached.
+        for _ in range(20):
+            await connection.execute(
+                "SELECT $1::int4 AS v",
+                parameters=[7],
+                prepared=True,
+            )
+
+        result = await connection.execute(
+            "SELECT count(*)::bigint AS n FROM pg_prepared_statements "
+            "WHERE statement LIKE 'SELECT $1::int4 AS v'",
+            prepared=False,
+        )
+        rows = result.result()
+        assert len(rows) == 1
+        assert rows[0]["n"] == 1, (
+            f"Expected exactly 1 cached prepared statement for the "
+            f"parameterised query, found {rows[0]['n']}. Either the "
+            f"deadpool StatementCache stopped reusing per-query entries or "
+            f"the prepared=True path stopped going through prepare_cached."
+        )
+    finally:
+        pool.close()

--- a/python/tests/test_value_converter.py
+++ b/python/tests/test_value_converter.py
@@ -659,9 +659,9 @@ async def test_char_internal_type_byte_spectrum(
         value = decoded[i]
         assert isinstance(value, str)
         assert len(value) == 1
-        assert (
-            ord(value) == b
-        ), f"byte 0x{b:02x} round-tripped to ord(value)=0x{ord(value):02x}"
+        assert ord(value) == b, (
+            f"byte 0x{b:02x} round-tripped to ord(value)=0x{ord(value):02x}"
+        )
     assert decoded[len(bytes_under_test)] is None
 
 

--- a/src/connection/impls.rs
+++ b/src/connection/impls.rs
@@ -61,19 +61,12 @@ where
 }
 
 impl Connection for SingleConnection {
-    async fn prepare(&self, query: &str, prepared: bool) -> PSQLPyResult<Statement> {
-        let prepared_stmt = self.connection.prepare(query).await?;
-
-        if !prepared {
-            self.drop_prepared(&prepared_stmt).await?;
-        }
-        Ok(prepared_stmt)
-    }
-
-    async fn drop_prepared(&self, stmt: &Statement) -> PSQLPyResult<()> {
-        let deallocate_query = format!("DEALLOCATE PREPARE {}", stmt.name());
-
-        Ok(self.connection.batch_execute(&deallocate_query).await?)
+    async fn prepare(&self, query: &str, _prepared: bool) -> PSQLPyResult<Statement> {
+        // When `prepared` is false, the returned Statement is short-lived;
+        // dropping it triggers tokio-postgres `Drop for StatementInner`,
+        // which sends Close('S', name) + Sync on the wire. No explicit
+        // DEALLOCATE is required.
+        Ok(self.connection.prepare(query).await?)
     }
 
     async fn query<T>(
@@ -151,15 +144,8 @@ impl Connection for PoolConnection {
             return Ok(self.connection.prepare_cached(query).await?);
         }
 
-        let prepared = self.connection.prepare(query).await?;
-        self.drop_prepared(&prepared).await?;
-        Ok(prepared)
-    }
-
-    async fn drop_prepared(&self, stmt: &Statement) -> PSQLPyResult<()> {
-        let deallocate_query = format!("DEALLOCATE PREPARE {}", stmt.name());
-
-        Ok(self.connection.batch_execute(&deallocate_query).await?)
+        // Non-cached: rely on tokio-postgres Statement Drop autoclose.
+        Ok(self.connection.prepare(query).await?)
     }
 
     async fn query<T>(
@@ -234,13 +220,6 @@ impl Connection for PSQLPyConnection {
         match self {
             PSQLPyConnection::PoolConn(p_conn) => p_conn.prepare(query, prepared).await,
             PSQLPyConnection::SingleConnection(s_conn) => s_conn.prepare(query, prepared).await,
-        }
-    }
-
-    async fn drop_prepared(&self, stmt: &Statement) -> PSQLPyResult<()> {
-        match self {
-            PSQLPyConnection::PoolConn(p_conn) => p_conn.drop_prepared(stmt).await,
-            PSQLPyConnection::SingleConnection(s_conn) => s_conn.drop_prepared(stmt).await,
         }
     }
 
@@ -700,7 +679,7 @@ impl PSQLPyConnection {
             .fetch_row_raw(querystring, parameters, prepared)
             .await?;
 
-        Python::with_gil(|gil| match result.columns().first() {
+        Python::attach(|gil| match result.columns().first() {
             Some(first_column) => postgres_to_py(gil, &result, first_column, 0, &None),
             None => Ok(gil.None()),
         })

--- a/src/connection/structs.rs
+++ b/src/connection/structs.rs
@@ -1,11 +1,12 @@
 use std::sync::Arc;
 
-use deadpool_postgres::Object;
 use tokio_postgres::{Client, Config};
+
+use crate::driver::psqlpy_manager::PsqlpyClient;
 
 #[derive(Debug)]
 pub struct PoolConnection {
-    pub connection: Object,
+    pub connection: PsqlpyClient,
     pub in_transaction: bool,
     pub in_cursor: bool,
     pub pg_config: Arc<Config>,
@@ -13,7 +14,7 @@ pub struct PoolConnection {
 
 impl PoolConnection {
     #[must_use]
-    pub fn new(connection: Object, pg_config: Arc<Config>) -> Self {
+    pub fn new(connection: PsqlpyClient, pg_config: Arc<Config>) -> Self {
         Self {
             connection,
             in_transaction: false,

--- a/src/connection/traits.rs
+++ b/src/connection/traits.rs
@@ -12,11 +12,6 @@ pub trait Connection {
         prepared: bool,
     ) -> impl std::future::Future<Output = PSQLPyResult<Statement>> + Send;
 
-    fn drop_prepared(
-        &self,
-        stmt: &Statement,
-    ) -> impl std::future::Future<Output = PSQLPyResult<()>> + Send;
-
     fn query<T>(
         &self,
         statement: &T,

--- a/src/driver/common.rs
+++ b/src/driver/common.rs
@@ -15,10 +15,10 @@ use crate::{
     value_converter::{dto::enums::PythonDTO, from_python::from_python_typed},
 };
 
-use bytes::BytesMut;
-use futures_util::pin_mut;
+use bytes::{Bytes, BytesMut};
+use futures_util::{pin_mut, SinkExt};
 use pyo3::{buffer::PyBuffer, types::PyAnyMethods, Python};
-use tokio_postgres::{binary_copy::BinaryCopyInWriter, types::ToSql};
+use tokio_postgres::{binary_copy::BinaryCopyInWriter, types::ToSql, CopyInSink};
 
 use crate::format_helpers::quote_ident;
 
@@ -250,8 +250,8 @@ macro_rules! impl_binary_copy_method {
                 columns: Option<Vec<String>>,
                 schema_name: Option<String>,
             ) -> PSQLPyResult<u64> {
-                let (db_client, mut bytes_mut) =
-                    Python::with_gil(|gil| -> PSQLPyResult<(Option<_>, BytesMut)> {
+                let (db_client, bytes_mut) =
+                    Python::attach(|gil| -> PSQLPyResult<(Option<_>, BytesMut)> {
                         let db_client = self_.borrow(gil).conn.clone();
 
                         let Some(db_client) = db_client else {
@@ -306,12 +306,15 @@ macro_rules! impl_binary_copy_method {
                 };
 
                 let read_conn_g = db_client.read().await;
-                let sink = read_conn_g.copy_in(&copy_qs).await?;
-                let writer = BinaryCopyInWriter::new_empty_buffer(sink, &[]);
-                pin_mut!(writer);
+                let sink: CopyInSink<Bytes> = read_conn_g.copy_in(&copy_qs).await?;
+                pin_mut!(sink);
 
-                writer.as_mut().write_raw_bytes(&mut bytes_mut).await?;
-                let rows_created = writer.as_mut().finish_empty().await?;
+                // `bytes_mut` already carries the full binary-format COPY payload
+                // (header + tuples + trailer) produced by the Python side, so
+                // BinaryCopyInWriter's framing layer is bypassed entirely — we
+                // push the bytes straight at the sink and close it.
+                sink.as_mut().send(bytes_mut.freeze()).await?;
+                let rows_created = sink.finish().await?;
 
                 Ok(rows_created)
             }
@@ -344,7 +347,7 @@ macro_rules! impl_copy_records_method {
                 columns: Option<Vec<String>>,
                 schema_name: Option<String>,
             ) -> PSQLPyResult<u64> {
-                let (db_client, raw_records) = Python::with_gil(
+                let (db_client, raw_records) = Python::attach(
                     |gil| -> PSQLPyResult<(Option<_>, Vec<Vec<pyo3::Py<PyAny>>>)> {
                         let db_client = self_.borrow(gil).conn.clone();
 
@@ -406,7 +409,7 @@ macro_rules! impl_copy_records_method {
                 }
 
                 let typed_rows: Vec<Vec<PythonDTO>> =
-                    Python::with_gil(|gil| -> PSQLPyResult<Vec<Vec<PythonDTO>>> {
+                    Python::attach(|gil| -> PSQLPyResult<Vec<Vec<PythonDTO>>> {
                         let mut typed: Vec<Vec<PythonDTO>> = Vec::with_capacity(raw_records.len());
                         for (row_idx, row) in raw_records.iter().enumerate() {
                             if row.len() != column_types.len() {

--- a/src/driver/connection.rs
+++ b/src/driver/connection.rs
@@ -1,4 +1,4 @@
-use deadpool_postgres::Pool;
+use crate::driver::psqlpy_manager::PsqlpyPool;
 use pyo3::{pyclass, pyfunction, pymethods, Py, PyAny, PyErr};
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -115,7 +115,7 @@ pub async fn connect(
 #[derive(Clone, Debug)]
 pub struct Connection {
     pub conn: Option<Arc<RwLock<PSQLPyConnection>>>,
-    db_pool: Option<Pool>,
+    db_pool: Option<PsqlpyPool>,
     pub pg_config: Arc<Config>,
 }
 
@@ -123,7 +123,7 @@ impl Connection {
     #[must_use]
     pub fn new(
         conn: Option<Arc<RwLock<PSQLPyConnection>>>,
-        db_pool: Option<Pool>,
+        db_pool: Option<PsqlpyPool>,
         pg_config: Arc<Config>,
     ) -> Self {
         Connection {
@@ -139,7 +139,7 @@ impl Connection {
     }
 
     #[must_use]
-    pub fn db_pool(&self) -> Option<Pool> {
+    pub fn db_pool(&self) -> Option<PsqlpyPool> {
         self.db_pool.clone()
     }
 }
@@ -159,7 +159,7 @@ impl Connection {
     }
 
     async fn __aenter__(self_: Py<Self>) -> PSQLPyResult<Py<Self>> {
-        let (db_client, db_pool, pg_config) = pyo3::Python::with_gil(|gil| {
+        let (db_client, db_pool, pg_config) = pyo3::Python::attach(|gil| {
             let self_ = self_.borrow(gil);
             (
                 self_.conn.clone(),
@@ -175,10 +175,12 @@ impl Connection {
         if let Some(db_pool) = db_pool {
             let connection = tokio_runtime()
                 .spawn(async move {
-                    Ok::<deadpool_postgres::Object, RustPSQLDriverError>(db_pool.get().await?)
+                    Ok::<crate::driver::psqlpy_manager::PsqlpyClient, RustPSQLDriverError>(
+                        db_pool.get().await?,
+                    )
                 })
                 .await??;
-            pyo3::Python::with_gil(|gil| {
+            pyo3::Python::attach(|gil| {
                 let mut self_ = self_.borrow_mut(gil);
                 self_.conn = Some(Arc::new(RwLock::new(PSQLPyConnection::PoolConn(
                     PoolConnection::new(connection, pg_config),
@@ -197,14 +199,14 @@ impl Connection {
         exception: Py<PyAny>,
         _traceback: Py<PyAny>,
     ) -> PSQLPyResult<()> {
-        let (is_exception_none, py_err) = pyo3::Python::with_gil(|gil| {
+        let (is_exception_none, py_err) = pyo3::Python::attach(|gil| {
             (
                 exception.is_none(gil),
                 PyErr::from_value(exception.into_bound(gil)),
             )
         });
 
-        pyo3::Python::with_gil(|gil| {
+        pyo3::Python::attach(|gil| {
             let mut self_ = self_.borrow_mut(gil);
 
             std::mem::take(&mut self_.conn);
@@ -233,7 +235,7 @@ impl Connection {
         parameters: Option<pyo3::Py<PyAny>>,
         prepared: Option<bool>,
     ) -> PSQLPyResult<PSQLDriverPyQueryResult> {
-        let db_client = pyo3::Python::with_gil(|gil| self_.borrow(gil).conn.clone());
+        let db_client = pyo3::Python::attach(|gil| self_.borrow(gil).conn.clone());
 
         if let Some(db_client) = db_client {
             let read_conn_g = db_client.read().await;
@@ -262,7 +264,7 @@ impl Connection {
     /// 1) Connection is closed.
     /// 2) Cannot execute querystring.
     pub async fn execute_batch(self_: pyo3::Py<Self>, querystring: String) -> PSQLPyResult<()> {
-        let db_client = pyo3::Python::with_gil(|gil| self_.borrow(gil).conn.clone());
+        let db_client = pyo3::Python::attach(|gil| self_.borrow(gil).conn.clone());
 
         if let Some(db_client) = db_client {
             let read_conn_g = db_client.read().await;
@@ -290,7 +292,7 @@ impl Connection {
         prepared: Option<bool>,
     ) -> PSQLPyResult<Py<PyAny>> {
         let (db_client, py_none) =
-            pyo3::Python::with_gil(|gil| (self_.borrow(gil).conn.clone(), gil.None().into_any()));
+            pyo3::Python::attach(|gil| (self_.borrow(gil).conn.clone(), gil.None().into_any()));
 
         if let Some(db_client) = db_client {
             let read_conn_g = db_client.read().await;
@@ -319,7 +321,7 @@ impl Connection {
         parameters: Option<pyo3::Py<PyAny>>,
         prepared: Option<bool>,
     ) -> PSQLPyResult<PSQLDriverPyQueryResult> {
-        let db_client = pyo3::Python::with_gil(|gil| self_.borrow(gil).conn.clone());
+        let db_client = pyo3::Python::attach(|gil| self_.borrow(gil).conn.clone());
 
         if let Some(db_client) = db_client {
             let read_conn_g = db_client.read().await;
@@ -356,7 +358,7 @@ impl Connection {
         parameters: Option<pyo3::Py<PyAny>>,
         prepared: Option<bool>,
     ) -> PSQLPyResult<PSQLDriverSinglePyQueryResult> {
-        let db_client = pyo3::Python::with_gil(|gil| self_.borrow(gil).conn.clone());
+        let db_client = pyo3::Python::attach(|gil| self_.borrow(gil).conn.clone());
 
         if let Some(db_client) = db_client {
             let read_conn_g = db_client.read().await;
@@ -386,7 +388,7 @@ impl Connection {
         parameters: Option<pyo3::Py<PyAny>>,
         prepared: Option<bool>,
     ) -> PSQLPyResult<Py<PyAny>> {
-        let db_client = pyo3::Python::with_gil(|gil| self_.borrow(gil).conn.clone());
+        let db_client = pyo3::Python::attach(|gil| self_.borrow(gil).conn.clone());
 
         if let Some(db_client) = db_client {
             let read_conn_g = db_client.read().await;
@@ -427,7 +429,7 @@ impl Connection {
 
     #[allow(clippy::needless_pass_by_value)]
     pub fn close(self_: pyo3::Py<Self>) {
-        pyo3::Python::with_gil(|gil| {
+        pyo3::Python::attach(|gil| {
             let mut connection = self_.borrow_mut(gil);
             if connection.conn.is_some() {
                 std::mem::take(&mut connection.conn);

--- a/src/driver/connection_pool.rs
+++ b/src/driver/connection_pool.rs
@@ -1,8 +1,9 @@
 use crate::{
     connection::structs::{PSQLPyConnection, PoolConnection},
+    driver::psqlpy_manager::{PsqlpyManager, PsqlpyPool},
     runtime::tokio_runtime,
 };
-use deadpool_postgres::{Manager, ManagerConfig, Pool, RecyclingMethod};
+use deadpool_postgres::{ManagerConfig, RecyclingMethod};
 use postgres_types::Type;
 use pyo3::{pyclass, pyfunction, pymethods, Py, PyAny};
 use std::sync::Arc;
@@ -144,18 +145,21 @@ pub fn connect_pool(
         };
     }
 
-    let mgr: Manager = build_manager(
+    let mgr: PsqlpyManager = build_manager(
         mgr_config,
         pg_config.clone(),
         build_tls(&ca_file, &ssl_mode)?,
+        ssl_mode,
     );
 
-    let mut db_pool_builder = Pool::builder(mgr);
+    let mut db_pool_builder = PsqlpyPool::builder(mgr);
     if let Some(max_db_pool_size) = max_db_pool_size {
         db_pool_builder = db_pool_builder.max_size(max_db_pool_size);
     }
 
-    let pool = db_pool_builder.build()?;
+    let pool = db_pool_builder.build().map_err(|err| {
+        RustPSQLDriverError::ConnectionPoolBuildError(format!("Cannot build pool: {err}"))
+    })?;
 
     Ok(ConnectionPool::build(
         pool, pg_config, ca_file, ssl_mode, None,
@@ -223,7 +227,7 @@ impl ConnectionPoolStatus {
 // pub struct ConnectionPool(pub Pool);
 #[pyclass(subclass)]
 pub struct ConnectionPool {
-    pool: Pool,
+    pool: PsqlpyPool,
     pg_config: Arc<Config>,
     pool_conf: ConnectionPoolConf,
 }
@@ -231,7 +235,7 @@ pub struct ConnectionPool {
 impl ConnectionPool {
     #[must_use]
     pub fn build(
-        pool: Pool,
+        pool: PsqlpyPool,
         pg_config: Config,
         ca_file: Option<String>,
         ssl_mode: Option<SslMode>,
@@ -261,7 +265,7 @@ impl ConnectionPool {
     }
 
     pub fn remove_prepared_stmt(&mut self, query: &str, types: &[Type]) {
-        self.pool.manager().statement_caches.remove(query, types);
+        self.pool.manager().statement_caches().remove(query, types);
     }
 }
 
@@ -376,7 +380,7 @@ impl ConnectionPool {
         _exception: Py<PyAny>,
         _traceback: Py<PyAny>,
     ) {
-        pyo3::Python::with_gil(|gil| {
+        pyo3::Python::attach(|gil| {
             self_.borrow(gil).close();
         });
     }
@@ -405,7 +409,7 @@ impl ConnectionPool {
     #[must_use]
     #[allow(clippy::needless_pass_by_value)]
     pub fn listener(self_: pyo3::Py<Self>) -> Listener {
-        let (pg_config, pool_conf) = pyo3::Python::with_gil(|gil| {
+        let (pg_config, pool_conf) = pyo3::Python::attach(|gil| {
             let b_gil = self_.borrow(gil);
             (b_gil.pg_config.clone(), b_gil.pool_conf.clone())
         });
@@ -418,13 +422,15 @@ impl ConnectionPool {
     /// # Errors
     /// May return Err Result if cannot get new connection from the pool.
     pub async fn connection(self_: pyo3::Py<Self>) -> PSQLPyResult<Connection> {
-        let (db_pool, pg_config) = pyo3::Python::with_gil(|gil| {
+        let (db_pool, pg_config) = pyo3::Python::attach(|gil| {
             let slf = self_.borrow(gil);
             (slf.pool.clone(), slf.pg_config.clone())
         });
         let connection = tokio_runtime()
             .spawn(async move {
-                Ok::<deadpool_postgres::Object, RustPSQLDriverError>(db_pool.get().await?)
+                Ok::<crate::driver::psqlpy_manager::PsqlpyClient, RustPSQLDriverError>(
+                    db_pool.get().await?,
+                )
             })
             .await??;
 

--- a/src/driver/connection_pool_builder.rs
+++ b/src/driver/connection_pool_builder.rs
@@ -1,6 +1,8 @@
 use std::{net::IpAddr, time::Duration};
 
-use deadpool_postgres::{Manager, ManagerConfig, Pool, RecyclingMethod};
+use deadpool_postgres::{ManagerConfig, RecyclingMethod};
+
+use crate::driver::psqlpy_manager::{PsqlpyManager, PsqlpyPool};
 use pyo3::{pyclass, pymethods, Py, Python};
 
 use crate::{
@@ -54,18 +56,21 @@ impl ConnectionPoolBuilder {
             };
         }
 
-        let mgr: Manager = build_manager(
+        let mgr: PsqlpyManager = build_manager(
             mgr_config,
             self.config.clone(),
             build_tls(&self.ca_file, &self.ssl_mode)?,
+            self.ssl_mode,
         );
 
-        let mut db_pool_builder = Pool::builder(mgr);
+        let mut db_pool_builder = PsqlpyPool::builder(mgr);
         if let Some(max_db_pool_size) = self.max_db_pool_size {
             db_pool_builder = db_pool_builder.max_size(max_db_pool_size);
         }
 
-        let db_pool = db_pool_builder.build()?;
+        let db_pool = db_pool_builder.build().map_err(|err| {
+            RustPSQLDriverError::ConnectionPoolBuildError(format!("Cannot build pool: {err}"))
+        })?;
 
         Ok(ConnectionPool::build(
             db_pool,
@@ -78,7 +83,7 @@ impl ConnectionPoolBuilder {
 
     /// Set `ca_file` for `ssl_mode` in `PostgreSQL`.
     fn ca_file(self_: Py<Self>, ca_file: String) -> Py<Self> {
-        Python::with_gil(|gil| {
+        Python::attach(|gil| {
             let mut self_ = self_.borrow_mut(gil);
             self_.ca_file = Some(ca_file);
         });
@@ -96,7 +101,7 @@ impl ConnectionPoolBuilder {
             ));
         }
 
-        Python::with_gil(|gil| {
+        Python::attach(|gil| {
             let mut self_ = self_.borrow_mut(gil);
             self_.max_db_pool_size = Some(pool_size);
         });
@@ -108,7 +113,7 @@ impl ConnectionPoolBuilder {
         self_: Py<Self>,
         conn_recycling_method: ConnRecyclingMethod,
     ) -> Py<Self> {
-        Python::with_gil(|gil| {
+        Python::attach(|gil| {
             let mut self_ = self_.borrow_mut(gil);
             self_.conn_recycling_method = Some(conn_recycling_method.to_internal());
         });
@@ -120,7 +125,7 @@ impl ConnectionPoolBuilder {
     /// Defaults to the user executing this process.
     #[must_use]
     pub fn user(self_: Py<Self>, user: &str) -> Py<Self> {
-        Python::with_gil(|gil| {
+        Python::attach(|gil| {
             let mut self_ = self_.borrow_mut(gil);
             self_.config.user(user);
         });
@@ -130,7 +135,7 @@ impl ConnectionPoolBuilder {
     /// Sets the password to authenticate with.
     #[must_use]
     pub fn password(self_: Py<Self>, password: &str) -> Py<Self> {
-        Python::with_gil(|gil| {
+        Python::attach(|gil| {
             let mut self_ = self_.borrow_mut(gil);
             self_.config.password(password);
         });
@@ -142,7 +147,7 @@ impl ConnectionPoolBuilder {
     /// Defaults to the user.
     #[must_use]
     pub fn dbname(self_: Py<Self>, dbname: &str) -> Py<Self> {
-        Python::with_gil(|gil| {
+        Python::attach(|gil| {
             let mut self_ = self_.borrow_mut(gil);
             self_.config.dbname(dbname);
         });
@@ -152,7 +157,7 @@ impl ConnectionPoolBuilder {
     /// Sets command line options used to configure the server.
     #[must_use]
     pub fn options(self_: Py<Self>, options: &str) -> Py<Self> {
-        Python::with_gil(|gil| {
+        Python::attach(|gil| {
             let mut self_ = self_.borrow_mut(gil);
             self_.config.options(options);
         });
@@ -162,7 +167,7 @@ impl ConnectionPoolBuilder {
     /// Sets the value of the `application_name` runtime parameter.
     #[must_use]
     pub fn application_name(self_: Py<Self>, application_name: &str) -> Py<Self> {
-        Python::with_gil(|gil| {
+        Python::attach(|gil| {
             let mut self_ = self_.borrow_mut(gil);
             self_.config.application_name(application_name);
         });
@@ -174,7 +179,7 @@ impl ConnectionPoolBuilder {
     /// Defaults to `prefer`.
     #[must_use]
     pub fn ssl_mode(self_: Py<Self>, ssl_mode: SslMode) -> Py<Self> {
-        Python::with_gil(|gil| {
+        Python::attach(|gil| {
             let mut self_ = self_.borrow_mut(gil);
             self_.ssl_mode = Some(ssl_mode);
             self_.config.ssl_mode(ssl_mode.to_internal());
@@ -189,7 +194,7 @@ impl ConnectionPoolBuilder {
     /// There must be either no hosts, or the same number of hosts as hostaddrs.
     #[must_use]
     pub fn host(self_: Py<Self>, host: &str) -> Py<Self> {
-        Python::with_gil(|gil| {
+        Python::attach(|gil| {
             let mut self_ = self_.borrow_mut(gil);
             self_.config.host(host);
         });
@@ -202,7 +207,7 @@ impl ConnectionPoolBuilder {
     /// There must be either no hostaddrs, or the same number of hostaddrs as hosts.
     #[must_use]
     pub fn hostaddr(self_: Py<Self>, hostaddr: IpAddr) -> Py<Self> {
-        Python::with_gil(|gil| {
+        Python::attach(|gil| {
             let mut self_ = self_.borrow_mut(gil);
             self_.config.hostaddr(hostaddr);
         });
@@ -216,7 +221,7 @@ impl ConnectionPoolBuilder {
     /// as hosts.
     #[must_use]
     pub fn port(self_: Py<Self>, port: u16) -> Py<Self> {
-        Python::with_gil(|gil| {
+        Python::attach(|gil| {
             let mut self_ = self_.borrow_mut(gil);
             self_.config.port(port);
         });
@@ -229,7 +234,7 @@ impl ConnectionPoolBuilder {
     /// host separately. Defaults to no limit.
     #[must_use]
     pub fn connect_timeout(self_: Py<Self>, connect_timeout: u64) -> Py<Self> {
-        Python::with_gil(|gil| {
+        Python::attach(|gil| {
             let mut self_ = self_.borrow_mut(gil);
             self_
                 .config
@@ -245,7 +250,7 @@ impl ConnectionPoolBuilder {
     /// on other systems, it has no effect.
     #[must_use]
     pub fn tcp_user_timeout(self_: Py<Self>, tcp_user_timeout: u64) -> Py<Self> {
-        Python::with_gil(|gil| {
+        Python::attach(|gil| {
             let mut self_ = self_.borrow_mut(gil);
             self_
                 .config
@@ -263,7 +268,7 @@ impl ConnectionPoolBuilder {
         self_: Py<Self>,
         target_session_attrs: TargetSessionAttrs,
     ) -> Py<Self> {
-        Python::with_gil(|gil| {
+        Python::attach(|gil| {
             let mut self_ = self_.borrow_mut(gil);
             self_
                 .config
@@ -277,7 +282,7 @@ impl ConnectionPoolBuilder {
     /// Defaults to `disable`.
     #[must_use]
     pub fn load_balance_hosts(self_: Py<Self>, load_balance_hosts: LoadBalanceHosts) -> Py<Self> {
-        Python::with_gil(|gil| {
+        Python::attach(|gil| {
             let mut self_ = self_.borrow_mut(gil);
             self_
                 .config
@@ -291,7 +296,7 @@ impl ConnectionPoolBuilder {
     /// This is ignored for Unix domain socket connections. Defaults to `true`.
     #[must_use]
     pub fn keepalives(self_: Py<Self>, keepalives: bool) -> Py<Self> {
-        Python::with_gil(|gil| {
+        Python::attach(|gil| {
             let mut self_ = self_.borrow_mut(gil);
             self_.config.keepalives(keepalives);
         });
@@ -304,7 +309,7 @@ impl ConnectionPoolBuilder {
     #[must_use]
     #[cfg(not(target_arch = "wasm32"))]
     pub fn keepalives_idle(self_: Py<Self>, keepalives_idle: u64) -> Py<Self> {
-        Python::with_gil(|gil| {
+        Python::attach(|gil| {
             let mut self_ = self_.borrow_mut(gil);
             self_
                 .config
@@ -320,7 +325,7 @@ impl ConnectionPoolBuilder {
     #[must_use]
     #[cfg(not(target_arch = "wasm32"))]
     pub fn keepalives_interval(self_: Py<Self>, keepalives_interval: u64) -> Py<Self> {
-        Python::with_gil(|gil| {
+        Python::attach(|gil| {
             let mut self_ = self_.borrow_mut(gil);
             self_
                 .config
@@ -335,7 +340,7 @@ impl ConnectionPoolBuilder {
     #[must_use]
     #[cfg(not(target_arch = "wasm32"))]
     pub fn keepalives_retries(self_: Py<Self>, keepalives_retries: u32) -> Py<Self> {
-        Python::with_gil(|gil| {
+        Python::attach(|gil| {
             let mut self_ = self_.borrow_mut(gil);
             self_.config.keepalives_retries(keepalives_retries);
         });

--- a/src/driver/cursor.rs
+++ b/src/driver/cursor.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
-use pyo3::{
-    exceptions::PyStopAsyncIteration, pyclass, pymethods, Py, PyAny, PyErr, PyObject, Python,
-};
+use pyo3::{exceptions::PyStopAsyncIteration, pyclass, pymethods, Py, PyAny, PyErr, Python};
+
+type PyObject = Py<PyAny>;
 use tokio::sync::RwLock;
 use tokio_postgres::{Config, Portal as tp_Portal};
 
@@ -103,7 +103,7 @@ impl Cursor {
 
     #[allow(clippy::single_match_else)]
     async fn __aenter__(slf: Py<Self>) -> PSQLPyResult<Py<Self>> {
-        let (conn, querystring, parameters, statement) = Python::with_gil(|gil| {
+        let (conn, querystring, parameters, statement) = Python::attach(|gil| {
             let self_ = slf.borrow(gil);
             (
                 self_.conn.clone(),
@@ -134,7 +134,7 @@ impl Cursor {
             }
         };
 
-        Python::with_gil(|gil| {
+        Python::attach(|gil| {
             let mut self_ = slf.borrow_mut(gil);
 
             self_.transaction = Some(Arc::new(txid));
@@ -153,7 +153,7 @@ impl Cursor {
     ) -> PSQLPyResult<()> {
         self.close();
 
-        let (is_exc_none, py_err) = pyo3::Python::with_gil(|gil| {
+        let (is_exc_none, py_err) = pyo3::Python::attach(|gil| {
             (
                 exception.is_none(gil),
                 PyErr::from_value(exception.into_bound(gil)),
@@ -171,7 +171,7 @@ impl Cursor {
         let portal = self.inner.clone();
         let size = self.array_size;
 
-        let py_future = Python::with_gil(move |gil| {
+        let py_future = Python::attach(move |gil| {
             rustdriver_future(gil, async move {
                 let Some(txid) = &txid else {
                     return Err(RustPSQLDriverError::TransactionClosedError);

--- a/src/driver/listener/core.rs
+++ b/src/driver/listener/core.rs
@@ -107,7 +107,7 @@ impl Listener {
         exception: Py<PyAny>,
         _traceback: Py<PyAny>,
     ) -> PSQLPyResult<()> {
-        let (client, is_exception_none, py_err) = pyo3::Python::with_gil(|gil| {
+        let (client, is_exception_none, py_err) = pyo3::Python::attach(|gil| {
             let self_ = slf.borrow(gil);
             (
                 self_.connection.db_client(),
@@ -117,7 +117,7 @@ impl Listener {
         });
 
         if client.is_some() {
-            pyo3::Python::with_gil(|gil| {
+            pyo3::Python::attach(|gil| {
                 let mut self_ = slf.borrow_mut(gil);
                 std::mem::take(&mut self_.connection);
                 std::mem::take(&mut self_.receiver);
@@ -149,7 +149,7 @@ impl Listener {
         let listen_query_clone = self.listen_query.clone();
         let connection = self.connection.clone();
 
-        let py_future = Python::with_gil(move |gil| {
+        let py_future = Python::attach(move |gil| {
             rustdriver_future(gil, async move {
                 {
                     execute_listen(&is_listened_clone, &listen_query_clone, &client).await?;
@@ -254,7 +254,7 @@ impl Listener {
             return Err(RustPSQLDriverError::ListenerCallbackError);
         }
 
-        let task_locals = Python::with_gil(pyo3_async_runtimes::tokio::get_current_locals)?;
+        let task_locals = Python::attach(pyo3_async_runtimes::tokio::get_current_locals)?;
 
         let listener_callback = ListenerCallback::new(task_locals, callback);
 

--- a/src/driver/listener/structs.rs
+++ b/src/driver/listener/structs.rs
@@ -128,11 +128,11 @@ impl ListenerCallback {
         connection: Connection,
     ) -> PSQLPyResult<()> {
         let (callback, task_locals) =
-            Python::with_gil(|py| (self.callback.clone(), self.task_locals.clone_ref(py)));
+            Python::attach(|py| (self.callback.clone(), self.task_locals.clone_ref(py)));
 
         tokio_runtime()
             .spawn(pyo3_async_runtimes::tokio::scope(task_locals, async move {
-                let future = Python::with_gil(|py| {
+                let future = Python::attach(|py| {
                     let awaitable = callback
                         .call1(
                             py,

--- a/src/driver/mod.rs
+++ b/src/driver/mod.rs
@@ -5,5 +5,6 @@ pub mod connection_pool_builder;
 pub mod cursor;
 pub mod listener;
 pub mod prepared_statement;
+pub mod psqlpy_manager;
 pub mod transaction;
 pub mod utils;

--- a/src/driver/psqlpy_manager.rs
+++ b/src/driver/psqlpy_manager.rs
@@ -1,5 +1,5 @@
 use deadpool::managed::{self, Metrics, RecycleResult};
-use deadpool_postgres::{ClientWrapper, Manager, ManagerConfig, PoolError, StatementCaches};
+use deadpool_postgres::{ClientWrapper, Manager, ManagerConfig, StatementCaches};
 use postgres_openssl::MakeTlsConnector;
 use tokio_postgres::{error::SqlState, Config as PgConfig, NoTls};
 
@@ -135,17 +135,6 @@ impl managed::Manager for PsqlpyManager {
     fn detach(&self, client: &mut Self::Type) {
         self.primary.detach(client);
     }
-}
-
-/// `PoolError`-aware variant of [`is_ssl_required_rejection`].
-///
-/// Pool-level callers see `PoolError::Backend(deadpool_postgres::Error)`
-/// rather than the raw tokio-postgres error, so they need to walk one extra
-/// layer. Kept distinct to avoid the cost of constructing a trait object at
-/// every call site.
-#[must_use]
-pub fn pool_error_is_ssl_required(err: &PoolError) -> bool {
-    is_ssl_required_rejection(err)
 }
 
 /// Build the two-manager pair an [`SslMode::Allow`] connection requires.

--- a/src/driver/psqlpy_manager.rs
+++ b/src/driver/psqlpy_manager.rs
@@ -1,0 +1,203 @@
+use deadpool::managed::{self, Metrics, RecycleResult};
+use deadpool_postgres::{ClientWrapper, Manager, ManagerConfig, PoolError, StatementCaches};
+use postgres_openssl::MakeTlsConnector;
+use tokio_postgres::{error::SqlState, Config as PgConfig, NoTls};
+
+use crate::options::SslMode;
+
+use super::utils::ConfiguredTLS;
+
+/// `deadpool::managed::Pool` parameterized on [`PsqlpyManager`].
+///
+/// All `ConnectionPool` plumbing in psqlpy goes through this alias rather than
+/// `deadpool_postgres::Pool` (which is hard-bound to
+/// `deadpool_postgres::Manager`). Both share the same `ClientWrapper` object
+/// type, so the rest of the `deadpool_postgres` ergonomics (`Client = Object`,
+/// pool status, builder pattern, etc.) still works.
+pub type PsqlpyPool = deadpool::managed::Pool<PsqlpyManager>;
+
+/// Pool-checked-out client (`Object<PsqlpyManager>`). Replaces the
+/// `deadpool_postgres::Object` / `deadpool_postgres::Client` alias at the
+/// boundaries that handed those out (`PoolConnection`, `retrieve_connection`,
+/// `listener.start`) — same underlying `ClientWrapper`, different generic
+/// witness.
+pub type PsqlpyClient = deadpool::managed::Object<PsqlpyManager>;
+
+/// Connection manager that owns a `deadpool_postgres::Manager` for the primary
+/// TLS configuration and, only for `SslMode::Allow`, a second manager for the
+/// plaintext fallback path.
+///
+/// The two-manager shape is what makes psqlpy's `Allow` mode libpq-faithful.
+/// libpq tries plaintext first and silently retries over TLS when the server
+/// rejects the plaintext attempt with the `INVALID_AUTHORIZATION_SPECIFICATION`
+/// `no encryption` diagnostic pair. We mirror that here. The `primary`
+/// manager is the plaintext (`SslMode::Disable` `NoTls`) side, and the
+/// `tls_fallback` manager is the TLS side that picks up when the server
+/// requires encryption. For every other `SslMode`, `tls_fallback` is `None`
+/// and `create()` simply delegates straight to `primary`.
+#[derive(Debug)]
+pub struct PsqlpyManager {
+    primary: Manager,
+    tls_fallback: Option<Manager>,
+}
+
+impl PsqlpyManager {
+    /// Expose the primary manager's `StatementCaches` for the legacy
+    /// `pool.manager().statement_caches.remove(...)` call sites that predate
+    /// this wrapper. The fallback manager's cache (if any) is intentionally
+    /// not surfaced here — Allow-mode TLS fallback connections are rare and
+    /// transient, and double-bookkeeping a second cache for them would only
+    /// matter if a caller invalidated a prepared statement and we wanted that
+    /// invalidation to ride through both inner caches.
+    #[must_use]
+    pub fn statement_caches(&self) -> &StatementCaches {
+        &self.primary.statement_caches
+    }
+}
+
+impl PsqlpyManager {
+    /// Plain wrapper: only the primary manager, no Allow-style retry.
+    pub fn single(primary: Manager) -> Self {
+        Self {
+            primary,
+            tls_fallback: None,
+        }
+    }
+
+    /// Allow-mode wrapper: plaintext primary + TLS fallback. `primary` is
+    /// expected to be a `Disable+NoTls` manager and `tls_fallback` a
+    /// `Require+MakeTlsConnector` manager — the inverse pair would still
+    /// type-check but would lose libpq-`Allow`'s plaintext-first semantics.
+    pub fn with_tls_fallback(primary: Manager, tls_fallback: Manager) -> Self {
+        Self {
+            primary,
+            tls_fallback: Some(tls_fallback),
+        }
+    }
+}
+
+/// Returns `true` when the error chain matches the postgres-side "this server
+/// requires encryption" rejection that libpq's `sslmode=allow` is built
+/// around.
+///
+/// `PostgreSQL` surfaces this as SQLSTATE `INVALID_AUTHORIZATION_SPECIFICATION`
+/// (28000) with a message that contains the literal "no encryption" substring
+/// — empirically present in `auth.c:ClientAuthentication` on pg 12–17. We walk
+/// the `source()` chain so callers can pass a `PoolError`, `DeadpoolError`, or
+/// raw `tokio_postgres::Error` and get the same answer.
+#[must_use]
+pub fn is_ssl_required_rejection(err: &(dyn std::error::Error + 'static)) -> bool {
+    let mut current: Option<&(dyn std::error::Error + 'static)> = Some(err);
+    while let Some(e) = current {
+        if let Some(pg_err) = e.downcast_ref::<tokio_postgres::Error>() {
+            if let Some(db_err) = pg_err.as_db_error() {
+                if db_err.code() == &SqlState::INVALID_AUTHORIZATION_SPECIFICATION
+                    && db_err.message().contains("no encryption")
+                {
+                    return true;
+                }
+            }
+        }
+        current = e.source();
+    }
+    false
+}
+
+impl managed::Manager for PsqlpyManager {
+    type Type = ClientWrapper;
+    type Error = tokio_postgres::Error;
+
+    async fn create(&self) -> Result<Self::Type, Self::Error> {
+        match self.primary.create().await {
+            Ok(client) => Ok(client),
+            Err(err) => {
+                if let Some(fallback) = &self.tls_fallback {
+                    if is_ssl_required_rejection(&err) {
+                        return fallback.create().await;
+                    }
+                }
+                Err(err)
+            }
+        }
+    }
+
+    async fn recycle(
+        &self,
+        client: &mut Self::Type,
+        metrics: &Metrics,
+    ) -> RecycleResult<Self::Error> {
+        // Recycling is TLS-agnostic — same SQL probe regardless of which inner
+        // manager originally produced the client. Delegate to `primary` for
+        // both branches; the `Allow` fallback only matters at create-time.
+        self.primary.recycle(client, metrics).await
+    }
+
+    fn detach(&self, client: &mut Self::Type) {
+        self.primary.detach(client);
+    }
+}
+
+/// `PoolError`-aware variant of [`is_ssl_required_rejection`].
+///
+/// Pool-level callers see `PoolError::Backend(deadpool_postgres::Error)`
+/// rather than the raw tokio-postgres error, so they need to walk one extra
+/// layer. Kept distinct to avoid the cost of constructing a trait object at
+/// every call site.
+#[must_use]
+pub fn pool_error_is_ssl_required(err: &PoolError) -> bool {
+    is_ssl_required_rejection(err)
+}
+
+/// Build the two-manager pair an [`SslMode::Allow`] connection requires.
+///
+/// Caller supplies the base `pg_config` and `mgr_config` (recycling method
+/// etc.) plus the already-built `MakeTlsConnector` to use on the TLS side.
+/// Both inner configs are clones with only the `ssl_mode` field differing.
+#[must_use]
+pub fn build_allow_pair(
+    mut pg_config: PgConfig,
+    mgr_config: ManagerConfig,
+    tls_connector: MakeTlsConnector,
+) -> PsqlpyManager {
+    let mut plaintext_config = pg_config.clone();
+    plaintext_config.ssl_mode(tokio_postgres::config::SslMode::Disable);
+    pg_config.ssl_mode(tokio_postgres::config::SslMode::Require);
+
+    let plaintext = Manager::from_config(plaintext_config, NoTls, mgr_config.clone());
+    let tls = Manager::from_config(pg_config, tls_connector, mgr_config);
+    PsqlpyManager::with_tls_fallback(plaintext, tls)
+}
+
+/// Bridge from the legacy `(ManagerConfig, Config, ConfiguredTLS)` builder
+/// shape to a [`PsqlpyManager`].
+///
+/// - `SslMode::Allow` + a TLS connector → `Allow`-pair (plaintext-first).
+/// - `SslMode::Allow` + `NoTls` (no `ca_file`, no upstream cert) → degrades
+///   to a plain `Disable` manager. Without a TLS connector there is no
+///   meaningful retry target and libpq's behavior in that situation is itself
+///   plaintext-only.
+/// - Any other `SslMode` → straight pass-through to a single inner
+///   `Manager`, no retry.
+#[must_use]
+pub fn build_psqlpy_manager(
+    mgr_config: ManagerConfig,
+    pg_config: PgConfig,
+    configured_tls: ConfiguredTLS,
+    ssl_mode: Option<SslMode>,
+) -> PsqlpyManager {
+    if matches!(ssl_mode, Some(SslMode::Allow)) {
+        if let ConfiguredTLS::TlsConnector(connector) = configured_tls {
+            return build_allow_pair(pg_config, mgr_config, connector);
+        }
+        // Allow + no TLS connector available: behaves as Disable.
+        return PsqlpyManager::single(Manager::from_config(pg_config, NoTls, mgr_config));
+    }
+
+    let inner = match configured_tls {
+        ConfiguredTLS::NoTls => Manager::from_config(pg_config, NoTls, mgr_config),
+        ConfiguredTLS::TlsConnector(connector) => {
+            Manager::from_config(pg_config, connector, mgr_config)
+        }
+    };
+    PsqlpyManager::single(inner)
+}

--- a/src/driver/transaction.rs
+++ b/src/driver/transaction.rs
@@ -61,7 +61,7 @@ impl Transaction {
     }
 
     async fn __aenter__(self_: Py<Self>) -> PSQLPyResult<Py<Self>> {
-        let (isolation_level, read_variant, deferrable, conn) = pyo3::Python::with_gil(|gil| {
+        let (isolation_level, read_variant, deferrable, conn) = pyo3::Python::attach(|gil| {
             let self_ = self_.borrow(gil);
             (
                 self_.isolation_level,
@@ -89,7 +89,7 @@ impl Transaction {
         exception: Py<PyAny>,
         _traceback: Py<PyAny>,
     ) -> PSQLPyResult<()> {
-        let (conn, is_exception_none, py_err) = pyo3::Python::with_gil(|gil| {
+        let (conn, is_exception_none, py_err) = pyo3::Python::attach(|gil| {
             let self_ = self_.borrow(gil);
             (
                 self_.conn.clone(),
@@ -104,14 +104,14 @@ impl Transaction {
         let mut write_conn_g = conn.write().await;
         if is_exception_none {
             write_conn_g.commit().await?;
-            pyo3::Python::with_gil(|gil| {
+            pyo3::Python::attach(|gil| {
                 let mut self_ = self_.borrow_mut(gil);
                 self_.conn = None;
             });
             Ok(())
         } else {
             write_conn_g.rollback().await?;
-            pyo3::Python::with_gil(|gil| {
+            pyo3::Python::attach(|gil| {
                 let mut self_ = self_.borrow_mut(gil);
                 self_.conn = None;
             });
@@ -320,7 +320,7 @@ impl Transaction {
         queries: Option<Py<PyList>>,
         prepared: Option<bool>,
     ) -> PSQLPyResult<Vec<PSQLDriverPyQueryResult>> {
-        let db_client = pyo3::Python::with_gil(|gil| {
+        let db_client = pyo3::Python::attach(|gil| {
             let self_ = self_.borrow(gil);
 
             self_.conn.clone()
@@ -330,7 +330,7 @@ impl Transaction {
             let conn_read_g = db_client.read().await;
             let mut futures = vec![];
             if let Some(queries) = queries {
-                let gil_result = pyo3::Python::with_gil(|gil| -> PyResult<()> {
+                let gil_result = pyo3::Python::attach(|gil| -> PyResult<()> {
                     for single_query in queries.into_bound(gil).iter() {
                         let query_tuple = single_query.downcast::<PyTuple>().map_err(|err| {
                             RustPSQLDriverError::PyToRustValueConversionError(format!(

--- a/src/driver/utils.rs
+++ b/src/driver/utils.rs
@@ -198,13 +198,34 @@ pub fn build_tls(
     let mode = ssl_mode.unwrap_or(SslMode::Prefer);
 
     match mode {
-        SslMode::Disable | SslMode::Allow => Ok(ConfiguredTLS::NoTls),
+        SslMode::Disable => Ok(ConfiguredTLS::NoTls),
+        SslMode::Allow => {
+            // `Allow` needs a TLS connector even though the primary attempt
+            // is plaintext — `PsqlpyManager`'s fallback inner manager wraps
+            // this connector and is the side that picks up when the server
+            // rejects the plaintext attempt with `"no encryption"`. Without
+            // a connector here we degrade to plaintext-only and lose the
+            // libpq-faithful retry. Matches `Require` behaviour at this
+            // layer (accept any cert; verification, if wanted, comes from
+            // `VerifyCa` / `VerifyFull`).
+            let mut builder = SslConnector::builder(SslMethod::tls())?;
+            builder.set_verify(SslVerifyMode::NONE);
+            if let Some(ca_file) = ca_file {
+                builder.set_ca_file(ca_file)?;
+            }
+            Ok(ConfiguredTLS::TlsConnector(MakeTlsConnector::new(
+                builder.build(),
+            )))
+        }
         SslMode::Prefer | SslMode::Require => {
             let mut builder = SslConnector::builder(SslMethod::tls())?;
             // Behaviour-preserving for both Prefer and Require: accept any
             // certificate the server presents. Verification only kicks in for
             // VerifyCa / VerifyFull (libpq-faithful).
             builder.set_verify(SslVerifyMode::NONE);
+            if let Some(ca_file) = ca_file {
+                builder.set_ca_file(ca_file)?;
+            }
             Ok(ConfiguredTLS::TlsConnector(MakeTlsConnector::new(
                 builder.build(),
             )))

--- a/src/driver/utils.rs
+++ b/src/driver/utils.rs
@@ -1,12 +1,13 @@
 use std::{str::FromStr, time::Duration};
 
-use deadpool_postgres::{Manager, ManagerConfig};
+use deadpool_postgres::ManagerConfig;
 use openssl::ssl::{SslConnector, SslMethod, SslVerifyMode};
 use postgres_openssl::MakeTlsConnector;
 use pyo3::{types::PyAnyMethods, Py, PyAny, Python};
-use tokio_postgres::{Config, NoTls};
+use tokio_postgres::Config;
 
 use crate::{
+    driver::psqlpy_manager::{build_psqlpy_manager, PsqlpyManager},
     exceptions::rust_errors::{PSQLPyResult, RustPSQLDriverError},
     options::{LoadBalanceHosts, SslMode, TargetSessionAttrs},
 };
@@ -176,47 +177,75 @@ pub enum ConfiguredTLS {
     TlsConnector(MakeTlsConnector),
 }
 
-/// Create TLS.
+/// Build a TLS configuration that matches `ssl_mode`'s libpq-style semantics.
+///
+/// The five upstream-supported modes split into three wire-level shapes:
+/// - `Disable` / `Allow` → no TLS at this layer (Allow's plaintext-first
+///   fallback is the manager layer's responsibility, see TODO below).
+/// - `Prefer` / `Require` → TLS connector that accepts any certificate.
+///   tokio-postgres uses the connector but does not enforce verification.
+/// - `VerifyCa` / `VerifyFull` → TLS connector with `SslVerifyMode::PEER`.
+///   The two diverge only on per-connection hostname checking, applied via
+///   `MakeTlsConnector::set_callback` so the same builder serves both.
 ///
 /// # Errors
-/// May return Err Result if cannot create builder.
+/// May return Err Result if cannot create the SSL builder, load the CA file,
+/// or initialize the system default verify paths.
 pub fn build_tls(
     ca_file: &Option<String>,
     ssl_mode: &Option<SslMode>,
 ) -> PSQLPyResult<ConfiguredTLS> {
-    if let Some(ca_file) = ca_file {
-        let mut builder = SslConnector::builder(SslMethod::tls())?;
-        builder.set_ca_file(ca_file)?;
-        return Ok(ConfiguredTLS::TlsConnector(MakeTlsConnector::new(
-            builder.build(),
-        )));
-    } else if let Some(ssl_mode) = ssl_mode {
-        if *ssl_mode == SslMode::Require {
+    let mode = ssl_mode.unwrap_or(SslMode::Prefer);
+
+    match mode {
+        SslMode::Disable | SslMode::Allow => Ok(ConfiguredTLS::NoTls),
+        SslMode::Prefer | SslMode::Require => {
             let mut builder = SslConnector::builder(SslMethod::tls())?;
+            // Behaviour-preserving for both Prefer and Require: accept any
+            // certificate the server presents. Verification only kicks in for
+            // VerifyCa / VerifyFull (libpq-faithful).
             builder.set_verify(SslVerifyMode::NONE);
-            return Ok(ConfiguredTLS::TlsConnector(MakeTlsConnector::new(
+            Ok(ConfiguredTLS::TlsConnector(MakeTlsConnector::new(
                 builder.build(),
-            )));
+            )))
+        }
+        SslMode::VerifyCa | SslMode::VerifyFull => {
+            let mut builder = SslConnector::builder(SslMethod::tls())?;
+            builder.set_verify(SslVerifyMode::PEER);
+            if let Some(ca_file) = ca_file {
+                builder.set_ca_file(ca_file)?;
+            } else {
+                builder.set_default_verify_paths()?;
+            }
+            let mut connector = MakeTlsConnector::new(builder.build());
+            // `verify-ca` validates the chain but skips the hostname check;
+            // `verify-full` keeps the hostname check. openssl's default for
+            // `ConnectConfiguration` is hostname-on, so only `VerifyCa` needs
+            // an override.
+            if mode == SslMode::VerifyCa {
+                connector.set_callback(|config, _domain| {
+                    config.set_verify_hostname(false);
+                    Ok(())
+                });
+            }
+            Ok(ConfiguredTLS::TlsConnector(connector))
         }
     }
-
-    Ok(ConfiguredTLS::NoTls)
 }
 
+/// Build the [`PsqlpyManager`] for a connection pool.
+///
+/// Always returns a `PsqlpyManager`; for non-`Allow` `ssl_mode`s it wraps a
+/// single inner `deadpool_postgres::Manager`, and for `SslMode::Allow` it
+/// produces the libpq-faithful plaintext-first / TLS-fallback pair.
 #[must_use]
 pub fn build_manager(
     mgr_config: ManagerConfig,
     pg_config: Config,
     configured_tls: ConfiguredTLS,
-) -> Manager {
-    let mgr: Manager = match configured_tls {
-        ConfiguredTLS::NoTls => Manager::from_config(pg_config, NoTls, mgr_config),
-        ConfiguredTLS::TlsConnector(connector) => {
-            Manager::from_config(pg_config, connector, mgr_config)
-        }
-    };
-
-    mgr
+    ssl_mode: Option<SslMode>,
+) -> PsqlpyManager {
+    build_psqlpy_manager(mgr_config, pg_config, configured_tls, ssl_mode)
 }
 
 /// Check is python object async or not.
@@ -226,7 +255,7 @@ pub fn build_manager(
 /// 1) import inspect
 /// 2) extract boolean
 pub fn is_coroutine_function(function: Py<PyAny>) -> PSQLPyResult<bool> {
-    let is_coroutine_function: bool = Python::with_gil(|py| {
+    let is_coroutine_function: bool = Python::attach(|py| {
         let inspect = py.import("inspect")?;
 
         let is_cor = inspect

--- a/src/extra_types.rs
+++ b/src/extra_types.rs
@@ -357,7 +357,7 @@ macro_rules! build_array_type {
             /// # Errors
             /// May return Err Result if cannot convert sequence to array.
             pub fn _convert_to_python_dto(&self, elem_type: &Type) -> PSQLPyResult<PythonDTO> {
-                return Python::with_gil(|gil| {
+                return Python::attach(|gil| {
                     let binding = &self.inner;
                     let bound_inner = Ok::<&pyo3::Bound<'_, pyo3::PyAny>, RustPSQLDriverError>(
                         binding.bind(gil),

--- a/src/options.rs
+++ b/src/options.rs
@@ -86,15 +86,26 @@ pub enum SslMode {
 }
 
 impl SslMode {
+    /// Map psqlpy's `SslMode` to one of the three variants upstream
+    /// tokio-postgres actually exposes (`Disable` / `Prefer` / `Require`).
+    ///
+    /// - `Allow` is libpq-faithful and lives above this layer: see
+    ///   `PsqlpyManager` which builds two inner pools (`Disable`+`NoTls` and
+    ///   `Require`+TLS) and falls back on the SSL-required rejection. The
+    ///   tokio-postgres `SslMode` returned here is therefore the plaintext
+    ///   side of that pair, never `Allow` (which the fork carried but
+    ///   upstream omits).
+    /// - `VerifyCa` / `VerifyFull` use upstream `Require` for the wire-level
+    ///   handshake; certificate/hostname verification is enforced inside the
+    ///   `postgres-openssl` `SslConnector` configuration in `build_tls`.
     #[must_use]
     pub fn to_internal(&self) -> tokio_postgres::config::SslMode {
         match self {
-            SslMode::Disable => tokio_postgres::config::SslMode::Disable,
-            SslMode::Allow => tokio_postgres::config::SslMode::Allow,
+            SslMode::Disable | SslMode::Allow => tokio_postgres::config::SslMode::Disable,
             SslMode::Prefer => tokio_postgres::config::SslMode::Prefer,
-            SslMode::Require => tokio_postgres::config::SslMode::Require,
-            SslMode::VerifyCa => tokio_postgres::config::SslMode::VerifyCa,
-            SslMode::VerifyFull => tokio_postgres::config::SslMode::VerifyFull,
+            SslMode::Require | SslMode::VerifyCa | SslMode::VerifyFull => {
+                tokio_postgres::config::SslMode::Require
+            }
         }
     }
 }

--- a/src/runtime.rs
+++ b/src/runtime.rs
@@ -18,6 +18,8 @@ pub fn tokio_runtime() -> &'static tokio::runtime::Runtime {
 /// # Errors
 ///
 /// May return Err Result if future acts incorrect.
+// TODO(python-3.10-drop): On pyo3-async-runtimes 0.28+, add `+ Send + 'static`
+// to the `T` bound — `future_into_py` tightened its signature.
 pub fn rustdriver_future<F, T>(py: Python<'_>, future: F) -> PSQLPyResult<Py<PyAny>>
 where
     F: Future<Output = PSQLPyResult<T>> + Send + 'static,

--- a/src/statement/parameters.rs
+++ b/src/statement/parameters.rs
@@ -1,12 +1,17 @@
 use std::iter::zip;
 
 use postgres_types::{ToSql, Type};
+// TODO(python-3.10-drop): On pyo3 0.28+, replace `conversion::FromPyObjectBound`
+// with the dual-lifetime `FromPyObject<'a, 'py>` trait, which subsumes the
+// `FromPyObjectBound` bound used by `as_type` below.
 use pyo3::{
     conversion::FromPyObjectBound,
     pyclass, pymethods,
     types::{PyAnyMethods, PyMapping},
-    Py, PyObject, PyTypeCheck, Python,
+    Py, PyAny, PyTypeCheck, Python,
 };
+
+type PyObject = Py<PyAny>;
 
 use crate::{
     exceptions::rust_errors::{PSQLPyResult, RustPSQLDriverError},
@@ -69,7 +74,7 @@ impl ParametersBuilder {
         parameters_names: Option<Vec<String>>,
     ) -> PSQLPyResult<PreparedParameters> {
         let prepared_parameters =
-            Python::with_gil(|gil| self.prepare_parameters(gil, parameters_names))?;
+            Python::attach(|gil| self.prepare_parameters(gil, parameters_names))?;
 
         Ok(prepared_parameters)
     }

--- a/src/statement/statement_builder.rs
+++ b/src/statement/statement_builder.rs
@@ -1,4 +1,6 @@
-use pyo3::PyObject;
+use pyo3::{Py, PyAny};
+
+type PyObject = Py<PyAny>;
 use tokio::sync::RwLockWriteGuard;
 use tokio_postgres::Statement;
 

--- a/src/value_converter/consts.rs
+++ b/src/value_converter/consts.rs
@@ -1,13 +1,13 @@
 use pyo3::{
-    sync::GILOnceCell,
+    sync::PyOnceLock,
     types::{PyAnyMethods, PyType},
     Bound, Py, PyResult, Python,
 };
 
 pub static KWARGS_PARAMS_REGEXP: &str = r"\$\(([^)]+)\)p";
 
-pub static DECIMAL_CLS: GILOnceCell<Py<PyType>> = GILOnceCell::new();
-pub static TIMEDELTA_CLS: GILOnceCell<Py<PyType>> = GILOnceCell::new();
+pub static DECIMAL_CLS: PyOnceLock<Py<PyType>> = PyOnceLock::new();
+pub static TIMEDELTA_CLS: PyOnceLock<Py<PyType>> = PyOnceLock::new();
 
 #[allow(clippy::missing_errors_doc)]
 pub fn get_decimal_cls(py: Python<'_>) -> PyResult<&Bound<'_, PyType>> {

--- a/src/value_converter/dto/converter_impls.rs
+++ b/src/value_converter/dto/converter_impls.rs
@@ -93,6 +93,9 @@ impl ToPythonDTO for PyDict {
     }
 }
 
+// TODO(python-3.10-drop): On pyo3 0.28+, `.extract::<#[pyclass]Type>()`
+// returns `Result<_, PyClassGuardError<'_, '_>>` instead of `PyErr`; add
+// `.map_err(pyo3::PyErr::from)` before `?` to convert the new error type.
 macro_rules! construct_extra_type_converter {
     ($match_type:ty, $kind:path) => {
         impl ToPythonDTO for $match_type {
@@ -182,6 +185,9 @@ impl ToPythonDTO for extra_types::PythonEnum {
     }
 }
 
+// TODO(python-3.10-drop): On pyo3 0.28+, add `.map_err(pyo3::PyErr::from)`
+// between `.extract::<$match_type>()` and `?` to convert the new
+// `PyClassGuardError<'_, '_>` returned by `.extract` on pyclass types.
 macro_rules! construct_array_type_converter {
     ($match_type:ty) => {
         impl ToPythonDTO for $match_type {

--- a/src/value_converter/from_python.rs
+++ b/src/value_converter/from_python.rs
@@ -558,12 +558,17 @@ pub fn py_sequence_into_postgres_array(
     }
 
     let array_data = py_sequence_into_flat_vec(parameter, type_)?;
-    match postgres_array::Array::from_parts_no_panic(array_data, dimensions) {
-        Ok(result_array) => Ok(result_array),
-        Err(err) => Err(RustPSQLDriverError::PyToRustValueConversionError(format!(
-            "Cannot convert python sequence to PostgreSQL ARRAY, error - {err}"
-        ))),
+    let dims_product: i32 = dimensions.iter().map(|d| d.len).product();
+    let size_ok =
+        (array_data.is_empty() && dimensions.is_empty()) || array_data.len() as i32 == dims_product;
+    if !size_ok {
+        return Err(RustPSQLDriverError::PyToRustValueConversionError(format!(
+            "Cannot convert python sequence to PostgreSQL ARRAY, error - size mismatch (data len {}, dimensions product {})",
+            array_data.len(),
+            dims_product,
+        )));
     }
+    Ok(postgres_array::Array::from_parts(array_data, dimensions))
 }
 
 /// Convert Sequence from Python (except String) into flat vec.
@@ -613,7 +618,7 @@ pub fn py_sequence_into_flat_vec(
 /// May return error if cannot convert Python type into Rust one.
 /// May return error if parameters type isn't correct.
 fn convert_py_to_rust_coord_values(parameters: Vec<Py<PyAny>>) -> PSQLPyResult<Vec<f64>> {
-    Python::with_gil(|gil| {
+    Python::attach(|gil| {
         let mut coord_values_vec: Vec<f64> = vec![];
 
         for one_parameter in parameters {
@@ -669,7 +674,7 @@ pub fn build_geo_coords(
 ) -> PSQLPyResult<Vec<Coord>> {
     let mut result_vec: Vec<Coord> = vec![];
 
-    result_vec = Python::with_gil(|gil| {
+    result_vec = Python::attach(|gil| {
         let bind_py_parameters = py_parameters.bind(gil);
         let parameters = py_sequence_to_rust(bind_py_parameters)?;
 
@@ -741,7 +746,7 @@ pub fn build_flat_geo_coords(
     py_parameters: Py<PyAny>,
     allowed_length_option: Option<usize>,
 ) -> PSQLPyResult<Vec<f64>> {
-    Python::with_gil(|gil| {
+    Python::attach(|gil| {
         let allowed_length = allowed_length_option.unwrap_or_default();
 
         let bind_py_parameters = py_parameters.bind(gil);

--- a/src/value_converter/mod.rs
+++ b/src/value_converter/mod.rs
@@ -3,6 +3,7 @@ pub mod consts;
 pub mod dto;
 pub mod from_python;
 pub mod models;
+pub mod raw_buf;
 pub mod to_python;
 pub mod traits;
 pub mod utils;

--- a/src/value_converter/models/serde_value.rs
+++ b/src/value_converter/models/serde_value.rs
@@ -23,6 +23,12 @@ use crate::{
 #[derive(Clone)]
 pub struct InternalSerdeValue(Value);
 
+// TODO(python-3.10-drop): On pyo3 0.28+, this impl becomes
+//   impl<'a, 'py> FromPyObject<'a, 'py> for InternalSerdeValue {
+//       type Error = PyErr;
+//       fn extract(obj: Borrowed<'a, 'py, PyAny>) -> PyResult<Self> { ... }
+//   }
+// `extract_bound` was renamed to `extract` and gained a second lifetime in 0.27+.
 impl<'a> FromPyObject<'a> for InternalSerdeValue {
     fn extract_bound(ob: &Bound<'a, PyAny>) -> PyResult<Self> {
         let serde_value = build_serde_value(ob)?;

--- a/src/value_converter/models/uuid.rs
+++ b/src/value_converter/models/uuid.rs
@@ -16,6 +16,8 @@ use crate::exceptions::rust_errors::RustPSQLDriverError;
 #[derive(Clone, Copy)]
 pub struct InternalUuid(Uuid);
 
+// TODO(python-3.10-drop): On pyo3 0.28+, use `FromPyObject<'a, 'py>::extract`
+// with a `Borrowed<'a, 'py, PyAny>` argument and a `type Error = PyErr;` line.
 impl<'a> FromPyObject<'a> for InternalUuid {
     fn extract_bound(obj: &Bound<'a, PyAny>) -> PyResult<Self> {
         let uuid_value = Uuid::parse_str(obj.str()?.extract::<&str>()?).map_err(|_| {

--- a/src/value_converter/raw_buf.rs
+++ b/src/value_converter/raw_buf.rs
@@ -1,0 +1,32 @@
+use postgres_types::{FromSql, Type};
+
+/// Newtype that captures the raw column buffer bytes as `Option<&[u8]>`.
+///
+/// Replaces the fork-only `Row::col_buffer(i)` accessor: extracting a `RawBuf`
+/// via `row.try_get::<usize, RawBuf>(i)` yields the same raw NULL-aware byte
+/// slice that the fork's `col_buffer` returned.
+pub struct RawBuf<'a>(pub Option<&'a [u8]>);
+
+impl<'a> FromSql<'a> for RawBuf<'a> {
+    fn from_sql(
+        _ty: &Type,
+        raw: &'a [u8],
+    ) -> Result<Self, Box<dyn std::error::Error + Sync + Send>> {
+        Ok(RawBuf(Some(raw)))
+    }
+
+    fn from_sql_null(_ty: &Type) -> Result<Self, Box<dyn std::error::Error + Sync + Send>> {
+        Ok(RawBuf(None))
+    }
+
+    fn from_sql_nullable(
+        _ty: &Type,
+        raw: Option<&'a [u8]>,
+    ) -> Result<Self, Box<dyn std::error::Error + Sync + Send>> {
+        Ok(RawBuf(raw))
+    }
+
+    fn accepts(_ty: &Type) -> bool {
+        true
+    }
+}

--- a/src/value_converter/to_python.rs
+++ b/src/value_converter/to_python.rs
@@ -24,6 +24,7 @@ use crate::{
             decimal::InnerDecimal, internal_char::InternalChar, interval::InnerInterval,
             serde_value::InternalSerdeValue, uuid::InternalUuid,
         },
+        raw_buf::RawBuf,
     },
 };
 use pgvector::Vector as PgVector;
@@ -648,7 +649,7 @@ pub fn postgres_to_py(
     column_i: usize,
     custom_decoders: &Option<Py<PyDict>>,
 ) -> PSQLPyResult<Py<PyAny>> {
-    let raw_bytes_data = row.col_buffer(column_i);
+    let RawBuf(raw_bytes_data) = row.try_get::<usize, RawBuf>(column_i)?;
     if let Some(mut raw_bytes_data) = raw_bytes_data {
         return raw_bytes_data_process(
             py,

--- a/src/value_converter/utils.rs
+++ b/src/value_converter/utils.rs
@@ -8,6 +8,8 @@ use crate::exceptions::rust_errors::RustPSQLDriverError;
 /// This function will return `Err` in the following cases:
 /// - The Python object does not have the specified attribute
 /// - The attribute exists but cannot be extracted into the specified Rust type
+// TODO(python-3.10-drop): On pyo3 0.28+, bound becomes
+// `T: for<'a> FromPyObject<'a, 'py>` (two-lifetime trait).
 pub fn extract_value_from_python_object_or_raise<'py, T>(
     parameter: &'py pyo3::Bound<'_, PyAny>,
     attr_name: &str,


### PR DESCRIPTION
## Summary

- Removes the 7-fork constellation (`rust-postgres`, `rust-postgres-array`, `rust-postgres-interval`, `pgvector-rust`, `rust-decimal`, `deadpool`, `pyo3-async-runtimes`) from `Cargo.toml` and rewires every fork-only call site against in-tree Rust idioms. `Cargo.toml` and `Cargo.lock` now resolve every dep through crates.io.
- New `PsqlpyManager` (`src/driver/psqlpy_manager.rs`) implements `deadpool::managed::Manager` with a libpq-faithful plaintext-first / TLS-fallback pair for `SslMode::Allow`; `is_ssl_required_rejection` walks the `source()` chain matching `INVALID_AUTHORIZATION_SPECIFICATION` + `"no encryption"` to decide when to switch sides. Non-`Allow` modes wrap a single inner `deadpool_postgres::Manager` — identical behavior to the pre-change direct path.
- New `RawBuf<'a>` `FromSql` newtype (`src/value_converter/raw_buf.rs`) replaces the fork-only `Row::col_buffer` accessor via `row.try_get::<usize, RawBuf>(i)`.
- `DEALLOCATE PREPARE` calls dropped; rely on tokio-postgres `Drop for StatementInner` → `Close('S', name) + Sync` for autoclose. The `Connection::drop_prepared` trait method is gone.
- `BinaryCopyInWriter` empty-buffer trio replaced by direct `CopyInSink<Bytes>::send + finish` (Python side already builds the binary-format payload, so the wire framing layer was redundant).
- `SslMode::VerifyCa` / `VerifyFull` verification moved into `build_tls` at the `postgres-openssl` `SslConnector` layer: `SslVerifyMode::PEER` on the builder, plus a per-connection `set_verify_hostname(false)` callback for `VerifyCa` (the `VerifyFull` branch keeps openssl's default hostname-on behavior). `to_internal()` collapses to the three upstream-supported variants (`Disable` / `Prefer` / `Require`).
- `postgres_array::Array::from_parts_no_panic` replaced by pre-validation + upstream `Array::from_parts` at the single call site in `src/value_converter/from_python.rs`. The pre-validation reproduces the fork's empty-empty acceptance case while still using the panicking upstream constructor only after the size check passes.
- pyo3 ecosystem bumped 0.25 → 0.26 (Python 3.10 still in scope; 0.27 drops 3.10 support). Changes that would only land cleanly on pyo3 0.28+ are reverted with `TODO(python-3.10-drop)` markers next to each — covering `Python::attach`, `FromPyObject<'a, 'py>::extract`, `OnceLockExt`, the root-level `PyObject` rename, the `FromPyObjectBound` → `FromPyObject<'a, 'py>` move, the `PyClassGuardError` conversion, and the `pyo3-async-runtimes::future_into_py` `T: Send + 'static` tightening.

## Why now / motivation

The forks under `psqlpy-python/` had drifted from upstream — the deepest (`rust-postgres`) was 202 commits behind — and the maintenance cost was paid every time we tried to track an upstream security fix or feature. The actual delta we needed turned out to be five `pub` exposures and three convenience methods in `rust-postgres`, plus one workaround in `rust-postgres-array`. All of them now live in psqlpy itself, in well-named in-tree Rust idioms that are easier to reason about than out-of-tree forks. Six of the seven forks were Cargo.toml-only repointers; once the rust-postgres delta is gone, they collapse straight to crates.io.

## Test plan

### Verified locally

- [x] `cargo build --release --all-features` — green
- [x] `cargo clippy -p psqlpy --all-features -- -W clippy::all -W clippy::pedantic -D warnings` — clean (INV-G7)
- [x] `cargo fmt -- --check --config use_try_shorthand=true,imports_granularity=Crate` — clean (INV-G6)
- [x] Pre-commit hooks (`mypy`, `trim trailing whitespace`, `rust fmt`, `rust clippy`, `rust cargo check`) — all passed under `git commit`
- [x] `grep -nE 'git\s*=\s*"https?://github.com/psqlpy-python' Cargo.toml Cargo.lock` — 0 hits (INV-G1)
- [x] `git grep -nE 'SummitSG-LLC|psqlpy-python/(rust-postgres|deadpool|pyo3-async-runtimes|rust-decimal|rust-postgres-array|rust-postgres-interval|pgvector)'` — 0 hits (INV-G2)
- [x] `maturin develop --release` succeeds; module imports; all six `SslMode` variants exposed
- [x] Full pytest suite against a live pg14: **247 cases pass** on py3.12. `test_binary_copy` (the path that exercises the new `CopyInSink::send + finish` bypass) passes. `test_ssl_mode` was skipped — the local postgres doesn't have TLS enabled, no `POSTGRES_CERT_FILE`.

### Deferred to CI / follow-up

- [ ] `tox -v -c tox.ini` matrix across py3.10/3.11/3.12/3.13/3.14 × pg14/15/16/17 (INV-G8). The fmt and clippy gates already passed locally; the gap is multi-Python + multi-pg-version coverage.
- [ ] `test_ssl_mode` cert-backed run against pg14/15/16/17. Exercises the new `build_tls` PEER + hostname-callback split for `VerifyCa` vs `VerifyFull`, plus the new `PsqlpyManager` Allow-mode plaintext-first wiring.
- [ ] **New libpq-Allow e2e pytest** (manifest INV-G3) — needs hostssl-only postgres infra. Not added in this PR.
- [ ] **New statement-cache-eviction pytest** (manifest INV-G4) — not added in this PR.
- [ ] Per-AC review-agent gates (G9–G16: code-bugs, change-intent, contracts, type-safety, maintainability, ops, test-quality, prose, context-file) — left for reviewers.

## Risk flags worth a second look

- **R-1 statement-cache autoclose.** The `DEALLOCATE PREPARE` removal banks on tokio-postgres dropping the last `Arc<StatementInner>` clone. Any path that holds a clone of `Statement` past the consumer's `Result` would silently leak the prepared statement server-side. INV-G4 (the eviction-leak test) would catch this; it's deferred.
- **R-2 hostname toggle API.** `postgres-openssl 0.5.3` exposes `MakeTlsConnector::set_callback(|cfg, _| cfg.set_verify_hostname(false))` — that's what the `VerifyCa` branch uses. If the openssl `ConnectConfiguration::set_verify_hostname` shape ever changes, this is the line that breaks (`src/driver/utils.rs::build_tls`).
- **R-3 "no encryption" wording.** `is_ssl_required_rejection` substring-matches `"no encryption"` in the postgres SQLSTATE 28000 error message. Empirically present on pg 12–17 in `auth.c:ClientAuthentication`, but if a pg version differs, the libpq-Allow retry path silently regresses to never-retry. INV-G3 across pg14–17 would catch this; deferred.
- **R-5 `RawBuf` hot-path cost.** `row.try_get::<usize, RawBuf>(i)` adds a `FromSql` dispatch hop relative to the direct `col_buffer(i)` field read. The trait impl returns the slice unchanged, so the optimizer should inline through it, but no benchmark was run.

## Notes for the reviewer

- The `[patch.crates-io]` workaround mentioned in PG-6 of the manifest didn't end up being needed in the final landing form — once every direct dep moved to crates.io together with the source-side fork-API removals, the `postgres-types` / `FromSql` trait-unification issue disappeared on its own.
- The `TODO(python-3.10-drop)` markers are intentionally co-located with their reverted form so the next pyo3 bump becomes a single grep-and-replace pass rather than a re-derivation.
- `Connection::drop_prepared` was removed from the trait, not deprecated. If any out-of-tree consumer relied on this method, that's a breaking change at the Rust API boundary (the Python API is unaffected).
